### PR TITLE
fix(workflows): remove unknown parameter for delete command

### DIFF
--- a/.github/workflows/blog-build-deploy.yml
+++ b/.github/workflows/blog-build-deploy.yml
@@ -415,5 +415,5 @@ jobs:
             for resourceId in $resources
             do
               echo "Deleting resource: $resourceId"
-              az resource delete --ids $resourceId --yes
+              az resource delete --ids $resourceId
             done


### PR DESCRIPTION
Removed `--yes` parameter from delete command, should resolve error on workflow run after closing PR.