### PR TITLE
render anchor in article section

### DIFF
--- a/apps/blog/src/app/components/about-me/about-me.component.ts
+++ b/apps/blog/src/app/components/about-me/about-me.component.ts
@@ -36,5 +36,12 @@ export class AboutMeComponent {
         "I will cover topics such as programming languages, frameworks, tools, best practices, workarounds that I've found and some completely unrelated topics too.",
       ],
     },
+    {
+      title: 'Where is the repository for this blog?',
+      content: [
+        'The repository for this blog is available on GitHub.',
+        'You can find it at [peterjokumsen/peterjokumsen-nx-workspace](https://github.com/peterjokumsen/peterjokumsen-nx-workspace?tab=readme-ov-file#peterjokumsen-blog).',
+      ],
+    },
   ];
 }

--- a/ng-libs/styles/src/lib/styles/global.scss
+++ b/ng-libs/styles/src/lib/styles/global.scss
@@ -7,6 +7,14 @@
 
 .main-block {
   @apply w-full;
+
+  a.link {
+    color: var(--primary-color);
+  }
+}
+
+a.link {
+  text-decoration: underline;
 }
 
 .pj-header {

--- a/ng-libs/ui-elements/package.json
+++ b/ng-libs/ui-elements/package.json
@@ -5,6 +5,7 @@
     "@angular/animations": "^17.2.0",
     "@angular/common": "^17.2.0",
     "@angular/core": "^17.2.0",
+    "@angular/platform-browser": "17.3.7",
     "@angular/router": "^17.2.0",
     "@nx/angular": "^18.3.4",
     "@fortawesome/angular-fontawesome": "^0.14.1",

--- a/ng-libs/ui-elements/src/lib/article/pipes/index.ts
+++ b/ng-libs/ui-elements/src/lib/article/pipes/index.ts
@@ -1,0 +1,1 @@
+export * from './split-to-anchor.pipe';

--- a/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.spec.ts
+++ b/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.spec.ts
@@ -66,7 +66,7 @@ describe('SplitToAnchorPipe', () => {
       });
 
       it('should return value with anchor tag', () => {
-        expect(result).toEqual('Hello to <a href="#">value</a>');
+        expect(result).toEqual('Hello to <a href="#" class="link">value</a>');
       });
 
       it('should sanitize url', () => {
@@ -78,7 +78,7 @@ describe('SplitToAnchorPipe', () => {
 
       it('should bypass security for anchor tag', () => {
         expect(domSanitizer.bypassSecurityTrustHtml).toHaveBeenCalledWith(
-          'Hello to <a href="#">value</a>',
+          'Hello to <a href="#" class="link">value</a>',
         );
       });
     });
@@ -92,7 +92,7 @@ describe('SplitToAnchorPipe', () => {
 
       it('should return value with anchor tags', () => {
         expect(result).toEqual(
-          'Hello to <a href="#">first link</a> and <a href="https://website.com" target="_blank">second link</a>',
+          'Hello to <a href="#" class="link">first link</a> and <a href="https://website.com" target="_blank" class="link">second link</a>',
         );
       });
     });

--- a/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.spec.ts
+++ b/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.spec.ts
@@ -1,0 +1,64 @@
+import { DomSanitizer } from '@angular/platform-browser';
+import { SecurityContext } from '@angular/core';
+import { SplitToAnchorPipe } from './split-to-anchor.pipe';
+import { TestBed } from '@angular/core/testing';
+
+describe('SplitToAnchorPipe', () => {
+  let pipe: SplitToAnchorPipe;
+  let domSanitizer: Partial<jest.Mocked<DomSanitizer>>;
+
+  beforeEach(() => {
+    domSanitizer = {
+      sanitize: jest.fn().mockImplementation((_, v) => v),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        // keep split
+        { provide: DomSanitizer, useValue: domSanitizer },
+        SplitToAnchorPipe,
+      ],
+    });
+
+    pipe = TestBed.inject(SplitToAnchorPipe);
+  });
+
+  it('should be created', () => {
+    expect(pipe).toBeTruthy();
+  });
+
+  describe('transform', () => {
+    let result: string;
+
+    describe('when value is regular string', () => {
+      beforeEach(() => {
+        result = pipe.transform('value');
+      });
+
+      it('should return value', () => {
+        expect(pipe.transform('value')).toEqual('value');
+      });
+
+      it('should not use sanitizer', () => {
+        expect(domSanitizer.sanitize).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when value has link markdown', () => {
+      beforeEach(() => {
+        result = pipe.transform('Hello to [value](#)');
+      });
+
+      it('should return value with anchor tag', () => {
+        expect(result).toEqual('Hello to <a href="#">value</a>');
+      });
+
+      it('should sanitize url', () => {
+        expect(domSanitizer.sanitize).toHaveBeenCalledWith(
+          SecurityContext.URL,
+          '#',
+        );
+      });
+    });
+  });
+});

--- a/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.ts
+++ b/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.ts
@@ -22,7 +22,7 @@ export class SplitToAnchorPipe implements PipeTransform {
       const target = sanitizedUrl?.startsWith('http') ? ' target="_blank"' : '';
       value = value.replace(
         fullMatch,
-        `<a href="${sanitizedUrl}"${target}>${text}</a>`,
+        `<a href="${sanitizedUrl}"${target} class="link">${text}</a>`,
       );
     }
 

--- a/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.ts
+++ b/ng-libs/ui-elements/src/lib/article/pipes/split-to-anchor.pipe.ts
@@ -1,0 +1,27 @@
+import { Pipe, PipeTransform, SecurityContext, inject } from '@angular/core';
+
+import { DomSanitizer } from '@angular/platform-browser';
+
+@Pipe({
+  name: 'splitToAnchor',
+  standalone: true,
+})
+export class SplitToAnchorPipe implements PipeTransform {
+  private _sanitizer = inject(DomSanitizer);
+
+  transform(value: string): string {
+    const regex = /\[(.*?)\]\((.*?)\)/g;
+    const matches = value.match(regex);
+    for (const match of matches ?? []) {
+      const [fullMatch, text, url] = match.match(/\[(.*?)\]\((.*?)\)/) ?? [];
+      if (!fullMatch) continue;
+
+      value = value.replace(
+        fullMatch,
+        `<a href="${this._sanitizer.sanitize(SecurityContext.URL, url)}">${text}</a>`,
+      );
+    }
+
+    return value;
+  }
+}

--- a/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.html
+++ b/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.html
@@ -2,6 +2,6 @@
   <h1 class="text-4xl font-bold">{{ section()?.title }}</h1>
 
   @for (content of contents(); track content) {
-    <p class="text-lg">{{ content }}</p>
+    <p class="text-lg" [innerHTML]="content | splitToAnchor"></p>
   }
 </section>

--- a/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.spec.ts
+++ b/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ArticleSectionComponent } from './article-section.component';
+import { MockPipe } from 'ng-mocks';
+import { SplitToAnchorPipe } from '../../pipes';
 
 describe('ArticleSectionComponent', () => {
   let component: ArticleSectionComponent;
@@ -9,7 +11,13 @@ describe('ArticleSectionComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ArticleSectionComponent],
-    }).compileComponents();
+    })
+      .overrideComponent(ArticleSectionComponent, {
+        set: {
+          imports: [MockPipe(SplitToAnchorPipe)],
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(ArticleSectionComponent);
     component = fixture.componentInstance;

--- a/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.ts
+++ b/ng-libs/ui-elements/src/lib/article/section/container/article-section.component.ts
@@ -7,11 +7,12 @@ import {
 import { PjUiArticleSection, PjUiContent } from '../../models';
 
 import { CommonModule } from '@angular/common';
+import { SplitToAnchorPipe } from '../../pipes';
 
 @Component({
   selector: 'pj-ui-article-section',
   standalone: true,
-  imports: [CommonModule],
+  imports: [CommonModule, SplitToAnchorPipe],
   templateUrl: './article-section.component.html',
   styleUrl: './article-section.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
Resolves: #28 

Updated to replace markdown link `[title](url)` format in content, into anchor tags.