### PR TITLE
extend markdown-parser to consume images and links

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -29,6 +29,9 @@ coverage:
       ts-libs_ts-utils:
         flags:
           - ts-libs_ts-utils
+      ts-libs_markdown-parser:
+        flags:
+          - ts-libs_markdown-parser
     project:
       default:
         target: auto
@@ -51,6 +54,9 @@ coverage:
       ts-libs_ts-utils:
         flags:
           - ts-libs_ts-utils
+      ts-libs_markdown-parser:
+        flags:
+          - ts-libs_markdown-parser
 flags:
   app_blog:
     paths:
@@ -70,3 +76,6 @@ flags:
   ts-libs_ts-utils:
     paths:
       - ts-libs/ts-utils
+  ts-libs_markdown-parser:
+    paths:
+      - ts-libs/markdown-parser

--- a/ts-libs/markdown-parser/src/lib/_models/index.ts
+++ b/ts-libs/markdown-parser/src/lib/_models/index.ts
@@ -1,2 +1,3 @@
+export * from './matched-content';
 export * from './read-content.fn';
 export * from './read-result';

--- a/ts-libs/markdown-parser/src/lib/_models/matched-content.ts
+++ b/ts-libs/markdown-parser/src/lib/_models/matched-content.ts
@@ -1,0 +1,6 @@
+import { MarkdownContent } from '../models';
+
+export interface MatchedContent {
+  matched: string;
+  content: MarkdownContent;
+}

--- a/ts-libs/markdown-parser/src/lib/helper-fns/README.md
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/README.md
@@ -42,3 +42,24 @@ Check if the line contains `tag` passed in
 ```typescript
 const containsImageTag = hasImage(line);
 ```
+
+## `splitRichContent`
+
+Used to split tokenized string into rich content and plain text. Will use the passed in mapping to resolve token into content, and any other strings will be turned into plain text content.
+
+**Usage**
+
+```typescript
+const content = splitRichContent('H*ll-', {
+  '*': { src: '/world', content: 'e', type: 'image' },
+  '-': { type: 'link', alt: 'o', href: '/hello' },
+});
+
+// content = [
+//   { type: 'text', content: 'H' },
+//   { type: 'image', src: '/world', content: 'e' },
+//   { type: 'text', content: 'l' },
+//   { type: 'text', content: 'l' },
+//   { type: 'link', alt: 'o', href: '/hello' },
+// ];
+```

--- a/ts-libs/markdown-parser/src/lib/helper-fns/README.md
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/README.md
@@ -32,3 +32,13 @@ Get the level of the heading for the line being read. This is used to determine 
 ```typescript
 const headingLevel = getHeadingLevel(line);
 ```
+
+## `lineHas`
+
+Check if the line contains `tag` passed in
+
+**Usage**
+
+```typescript
+const containsImageTag = hasImage(line);
+```

--- a/ts-libs/markdown-parser/src/lib/helper-fns/index.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/index.ts
@@ -1,2 +1,5 @@
 export * from './get-content-type';
 export * from './get-header-level';
+export * from './line-has';
+export * from './regex-patterns';
+export * from './split-rich-content';

--- a/ts-libs/markdown-parser/src/lib/helper-fns/line-has.spec.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/line-has.spec.ts
@@ -1,0 +1,71 @@
+import { lineHas } from './line-has';
+
+describe('lineHas', () => {
+  let tag: Parameters<typeof lineHas>[0];
+
+  describe(`'image'`, () => {
+    beforeEach(() => {
+      tag = 'image';
+    });
+
+    describe.each([
+      'This is a line without an image',
+      '',
+      '![alt text](https://www.example.com/image.jpg',
+    ])('when the line is "%s"', (line) => {
+      it('should return false', () => {
+        const result = lineHas(tag, line);
+        expect(result).toBe(false);
+      });
+    });
+
+    describe.each([
+      '![alt text](https://www.example.com/image.jpg)',
+      'start ![alt text](https://www.example.com/image.jpg) end',
+      '[![alt text](https://www.example.com/image.jpg)](https://www.example.com)',
+    ])('when the line is "%s"', (line) => {
+      it('should be true', () => {
+        const result = lineHas(tag, line);
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe(`'link'`, () => {
+    beforeEach(() => {
+      tag = 'link';
+    });
+
+    describe.each(['This is a line without a link', ''])(
+      'when the line is "%s"',
+      (line) => {
+        it('should return false', () => {
+          const result = lineHas(tag, line);
+          expect(result).toBe(false);
+        });
+      },
+    );
+
+    describe.each([
+      '[alt text](https://www.example.com)',
+      'start [alt text](https://www.example.com) end',
+    ])('when the line is "%s"', (line) => {
+      it('should be true', () => {
+        const result = lineHas(tag, line);
+        expect(result).toBe(true);
+      });
+    });
+  });
+
+  describe('when the tag does not have a Regex pattern', () => {
+    it('should throw an error', () => {
+      const expectedError = [
+        "No search pattern for 'header'.",
+        "Unable to find 'header' content in line 'line'",
+      ].join(' ');
+      expect(() =>
+        lineHas('header' as Parameters<typeof lineHas>[0], 'line'),
+      ).toThrowError(expectedError);
+    });
+  });
+});

--- a/ts-libs/markdown-parser/src/lib/helper-fns/line-has.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/line-has.ts
@@ -1,0 +1,13 @@
+import { RichContentType } from '../models';
+import { regexPatterns } from './regex-patterns';
+
+export function lineHas(tag: RichContentType, line: string): boolean {
+  const pattern = regexPatterns[tag];
+  if (!pattern) {
+    throw new Error(
+      `No search pattern for '${tag}'. Unable to find '${tag}' content in line '${line}'`,
+    );
+  }
+
+  return pattern.test(line);
+}

--- a/ts-libs/markdown-parser/src/lib/helper-fns/regex-patterns.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/regex-patterns.ts
@@ -1,0 +1,6 @@
+import { MarkdownContentType } from '../models';
+
+export const regexPatterns: Partial<Record<MarkdownContentType, RegExp>> = {
+  image: /!\[(.*?)]\((.*?)\)/,
+  link: /\[(.*?)]\((.*?)\)/,
+};

--- a/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.spec.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.spec.ts
@@ -1,0 +1,44 @@
+import { MatchedContent } from '../_models';
+import { splitRichContent } from './split-rich-content';
+
+describe('splitRichContent', () => {
+  it('should split rich content into text and rich content', () => {
+    const line = 'a __b__ c __d__ e f g c __d__ e';
+    const richContentMap: { [key: string]: MatchedContent } = {
+      __b__: { matched: 'abc', content: { type: 'horizontal-rule' } },
+      __d__: { matched: 'def', content: { type: 'code', content: 'code' } },
+    };
+
+    const result = splitRichContent(line, richContentMap);
+    expect(result).toEqual([
+      { type: 'text', content: 'a ' },
+      { type: 'horizontal-rule' },
+      { type: 'text', content: ' c ' },
+      { type: 'code', content: 'code' },
+      { type: 'text', content: ' e f g c ' },
+      { type: 'code', content: 'code' },
+      { type: 'text', content: ' e' },
+    ]);
+  });
+
+  it('should return text if no rich content is found', () => {
+    const line = 'a b c d e f g c d e';
+    const richContentMap: { [key: string]: MatchedContent } = {
+      x: { matched: 'abc', content: { type: 'horizontal-rule' } },
+      y: { matched: 'def', content: { type: 'code', content: 'code' } },
+    };
+
+    const result = splitRichContent(line, richContentMap);
+    expect(result).toEqual([{ type: 'text', content: line }]);
+  });
+
+  it('should return rich content if no additional text is found', () => {
+    const line = '__link0__';
+    const richContentMap: { [key: string]: MatchedContent } = {
+      __link0__: { matched: 'd', content: { type: 'code', content: 'code' } },
+    };
+
+    const result = splitRichContent(line, richContentMap);
+    expect(result).toEqual([{ type: 'code', content: 'code' }]);
+  });
+});

--- a/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.ts
@@ -2,13 +2,12 @@ import { MarkdownContent } from '../models';
 import { MatchedContent } from '../_models';
 
 export function splitRichContent(
-  content: string,
+  rawContent: string,
   richContentMap: { [key: string]: MatchedContent },
 ): MarkdownContent[] {
   const result: MarkdownContent[] = [];
-  for (const split of content.split(
-    new RegExp(`(${Object.keys(richContentMap).join('|')})`),
-  )) {
+  const contentKeys = Object.keys(richContentMap).join('|');
+  for (const split of rawContent.split(new RegExp(`(${contentKeys})`))) {
     if (!split) continue;
     if (split in richContentMap) {
       result.push(richContentMap[split].content);

--- a/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.ts
+++ b/ts-libs/markdown-parser/src/lib/helper-fns/split-rich-content.ts
@@ -1,0 +1,21 @@
+import { MarkdownContent } from '../models';
+import { MatchedContent } from '../_models';
+
+export function splitRichContent(
+  content: string,
+  richContentMap: { [key: string]: MatchedContent },
+): MarkdownContent[] {
+  const result: MarkdownContent[] = [];
+  for (const split of content.split(
+    new RegExp(`(${Object.keys(richContentMap).join('|')})`),
+  )) {
+    if (!split) continue;
+    if (split in richContentMap) {
+      result.push(richContentMap[split].content);
+    } else {
+      result.push({ type: 'text', content: split });
+    }
+  }
+
+  return result;
+}

--- a/ts-libs/markdown-parser/src/lib/models/index.ts
+++ b/ts-libs/markdown-parser/src/lib/models/index.ts
@@ -1,2 +1,3 @@
 export * from './markdown-content';
 export * from './markdown-content-type';
+export * from './rich-content-type';

--- a/ts-libs/markdown-parser/src/lib/models/markdown-content-type.ts
+++ b/ts-libs/markdown-parser/src/lib/models/markdown-content-type.ts
@@ -8,4 +8,5 @@ export type MarkdownContentType =
   | 'horizontal-rule'
   | 'image'
   | 'link'
-  | 'paragraph';
+  | 'paragraph'
+  | 'text';

--- a/ts-libs/markdown-parser/src/lib/models/markdown-content.ts
+++ b/ts-libs/markdown-parser/src/lib/models/markdown-content.ts
@@ -38,6 +38,11 @@ export interface MarkdownHorizontalRule extends HasMarkdownContentType {
   type: 'horizontal-rule';
 }
 
+export interface MarkdownText extends HasMarkdownContentType {
+  type: 'text';
+  content: string;
+}
+
 export interface MarkdownImage extends HasMarkdownContentType {
   type: 'image';
   src: string;
@@ -66,4 +71,5 @@ export type MarkdownContent =
   | MarkdownImage
   | MarkdownLink
   | MarkdownSection
+  | MarkdownText
   | MarkdownParagraph;

--- a/ts-libs/markdown-parser/src/lib/models/rich-content-type.ts
+++ b/ts-libs/markdown-parser/src/lib/models/rich-content-type.ts
@@ -1,0 +1,3 @@
+import { MarkdownContentType } from './markdown-content-type';
+
+export type RichContentType = Extract<MarkdownContentType, 'image' | 'link'>;

--- a/ts-libs/markdown-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/markdown-parser/src/lib/parse-markdown.spec.ts
@@ -46,71 +46,176 @@ describe('parseMarkdown', () => {
     fileName: string,
     expectation: MarkdownSectionExpectation,
   ) {
-    describe(`when reading ${fileName}`, () => {
-      let sections: MarkdownSection[];
+    let sections: MarkdownSection[];
 
-      beforeEach(() => {
-        const markdown = fs.readFileSync(
-          path.join(__dirname, `./test-mds/${fileName}`),
-          'utf-8',
-        );
-        sections = parseMarkdown(markdown);
-      });
+    beforeEach(() => {
+      const markdown = fs.readFileSync(
+        path.join(__dirname, `./test-mds/${fileName}`),
+        'utf-8',
+      );
+      sections = parseMarkdown(markdown);
+    });
 
-      const multiple = expectation.expectedTitles.length > 1;
-      it(`should have section${multiple ? 's' : ''} with title of ${multiple ? JSON.stringify(expectation.expectedTitles) : `"${expectation.expectedTitles[0]}"`}`, () => {
-        expect(sections.map((s) => s.title)).toEqual(
-          expectation.expectedTitles,
-        );
-      });
+    const multiple = expectation.expectedTitles.length > 1;
+    it(`should have title${multiple ? 's' : ''} of ${multiple ? JSON.stringify(expectation.expectedTitles) : `"${expectation.expectedTitles[0]}"`}`, () => {
+      expect(sections.map((s) => s.title)).toEqual(expectation.expectedTitles);
+    });
 
-      it('should have expected content', () => {
-        expect(sections.map((s) => s.content)).toEqual(
-          expectation.expectedContents,
-        );
-      });
+    it('should have expected content', () => {
+      expect(sections.map((s) => s.content)).toEqual(
+        expectation.expectedContents,
+      );
     });
   }
 
-  testMarkdownFile('basic.md', {
-    expectedTitles: ['Section title'],
-    expectedContents: [
-      [
-        {
-          type: 'paragraph',
-          content: 'Section text.',
-        },
+  describe(`when reading basic.md`, () => {
+    testMarkdownFile('basic.md', {
+      expectedTitles: ['Section title'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: 'Section text.',
+          },
+        ],
       ],
-    ],
+    });
   });
 
-  testMarkdownFile('no-title.md', {
-    expectedTitles: [''],
-    expectedContents: [
-      [
-        {
-          type: 'paragraph',
-          content: 'No title here.',
-        },
+  describe(`when reading no-title.md`, () => {
+    testMarkdownFile('no-title.md', {
+      expectedTitles: [''],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: 'No title here.',
+          },
+        ],
       ],
-    ],
+    });
   });
 
-  testMarkdownFile('multiple-sections.md', {
-    expectedTitles: ['Section 1', 'Section 2'],
-    expectedContents: [
-      [
-        {
-          type: 'paragraph',
-          content: 'This is the first section.',
-        },
+  describe(`when reading multiple-sections.md`, () => {
+    testMarkdownFile('multiple-sections.md', {
+      expectedTitles: ['Section 1', 'Section 2'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: 'This is the first section.',
+          },
+        ],
+        [
+          {
+            type: 'paragraph',
+            content: 'This is the second section.',
+          },
+        ],
       ],
-      [
-        {
-          type: 'paragraph',
-          content: 'This is the second section.',
-        },
+    });
+  });
+
+  fdescribe(`when reading image-and-link.md`, () => {
+    testMarkdownFile('image-and-link.md', {
+      expectedTitles: ['Test link and image'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                content: 'This is a ',
+              },
+              {
+                type: 'link',
+                content: [{ type: 'text', content: 'link' }],
+                href: '/link',
+              },
+              {
+                type: 'text',
+                content: ' and this is an ',
+              },
+              {
+                type: 'image',
+                alt: 'image',
+                src: '/image',
+              },
+              {
+                type: 'text',
+                content: '.',
+              },
+            ],
+          },
+        ],
       ],
-    ],
+    });
+  });
+
+  fdescribe(`when reading link-only.md`, () => {
+    testMarkdownFile('link-only.md', {
+      expectedTitles: ['Line with only link'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'link',
+                content: [{ type: 'text', content: 'link' }],
+                href: '/link',
+              },
+            ],
+          },
+        ],
+      ],
+    });
+  });
+
+  fdescribe(`when reading image-only.md`, () => {
+    testMarkdownFile('image-only.md', {
+      expectedTitles: ['Line with only image'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'image',
+                alt: 'image',
+                src: '/image',
+              },
+            ],
+          },
+        ],
+      ],
+    });
+  });
+
+  fdescribe(`when reading link-with-image.md`, () => {
+    testMarkdownFile('link-with-image.md', {
+      expectedTitles: ['Image as link content'],
+      expectedContents: [
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'link',
+                content: [
+                  {
+                    type: 'image',
+                    alt: 'image',
+                    src: '/image',
+                  },
+                ],
+                href: '/link',
+              },
+            ],
+          },
+        ],
+      ],
+    });
   });
 });

--- a/ts-libs/markdown-parser/src/lib/reader-fns/README.md
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/README.md
@@ -100,3 +100,16 @@ Function to use when the content type is `'section'`.
 Will take the starting line as the title of the section, push the lines until the next section or the end of the Markdown as the content of the section, and return the section.
 
 When a line being read is of type `'section'`, will check the header level Using [getHeaderLevel](../helper-fns/README.md#getheaderlevel), and if the header level is greater than the current header level, will recursively call `readSection` to get the child section. And if the header level is less than or equal to the current header level, will return the section, with a start index that should get the calling function to read the new section.
+
+### `matchRichContent`
+
+Function to use to return matches found by the tag passed in. The provided `matched` property should be swapped outh with a token to symbolize the content.
+
+**Usage**
+
+```typescript
+for (const { content, matched } of matchRichContent('link', '[hello](/world)')) {
+  // content = { type: 'link', alt: 'hello', href: '/world' }
+  // matched = '[hello](/world)'
+|
+```

--- a/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.spec.ts
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.spec.ts
@@ -1,0 +1,128 @@
+import { MarkdownContent, RichContentType } from '../models';
+
+import { matchRichContent } from './match-rich-content';
+
+describe('readRichContent', () => {
+  let type: RichContentType;
+
+  describe("when type is 'image'", () => {
+    beforeEach(() => {
+      type = 'image';
+    });
+
+    describe('and content does not have image', () => {
+      it('should return empty', () => {
+        const result = matchRichContent(type, 'no image here');
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('and content has image', () => {
+      it('should return resolved image', () => {
+        const result = matchRichContent(
+          type,
+          '![alt text](https://example.com/image.jpg)',
+        );
+
+        const expectedContent: MarkdownContent = {
+          type: 'image',
+          alt: 'alt text',
+          src: 'https://example.com/image.jpg',
+        };
+        expect(result).toEqual([
+          {
+            matched: '![alt text](https://example.com/image.jpg)',
+            content: expectedContent,
+          },
+        ]);
+      });
+    });
+
+    describe('and content has multiple images', () => {
+      it('should return resolved images', () => {
+        const result = matchRichContent(
+          type,
+          '![alt text](/image.jpg) ![alt text](/image.jpg) [![other](/image.png)](/link)',
+        );
+
+        const firstContent: MarkdownContent = {
+          type: 'image',
+          alt: 'alt text',
+          src: '/image.jpg',
+        };
+        const secondContent: MarkdownContent = {
+          type: 'image',
+          alt: 'other',
+          src: '/image.png',
+        };
+        expect(result).toEqual([
+          {
+            matched: '![alt text](/image.jpg)',
+            content: firstContent,
+          },
+          {
+            matched: '![other](/image.png)',
+            content: secondContent,
+          },
+        ]);
+      });
+    });
+  });
+
+  describe("when type is 'link'", () => {
+    describe('and content does not have link', () => {
+      it('should return empty', () => {
+        const result = matchRichContent('link', 'no link here');
+        expect(result).toEqual([]);
+      });
+    });
+
+    describe('and content has link', () => {
+      it('should return resolved link', () => {
+        const result = matchRichContent('link', '[text](https://example.com)');
+
+        const expectedContent: MarkdownContent = {
+          type: 'link',
+          content: 'text',
+          href: 'https://example.com',
+        };
+        expect(result).toEqual([
+          {
+            matched: '[text](https://example.com)',
+            content: expectedContent,
+          },
+        ]);
+      });
+    });
+
+    describe('and content has multiple links', () => {
+      it('should return resolved links', () => {
+        const result = matchRichContent(
+          'link',
+          '[text](/link-1) [text](/link-1) [other](/link-2)',
+        );
+
+        const firstContent: MarkdownContent = {
+          type: 'link',
+          content: 'text',
+          href: '/link-1',
+        };
+        const secondContent: MarkdownContent = {
+          type: 'link',
+          content: 'other',
+          href: '/link-2',
+        };
+        expect(result).toEqual([
+          {
+            matched: '[text](/link-1)',
+            content: firstContent,
+          },
+          {
+            matched: '[other](/link-2)',
+            content: secondContent,
+          },
+        ]);
+      });
+    });
+  });
+});

--- a/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.ts
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.ts
@@ -1,0 +1,51 @@
+import { MarkdownContent, RichContentType } from '../models';
+
+import { MatchedContent } from '../_models';
+import { regexPatterns } from '../helper-fns/regex-patterns';
+
+export function matchRichContent(
+  type: RichContentType,
+  content: string,
+): MatchedContent[] {
+  const pattern = regexPatterns[type];
+  const result: MatchedContent[] = [];
+  if (!pattern) {
+    return result;
+  }
+
+  const matches = content.matchAll(new RegExp(pattern, 'g'));
+  if (!matches) {
+    return result;
+  }
+
+  for (const match of matches) {
+    const [matched, first, second] = match ?? ['', '', ''];
+    if (!matched || result.some(({ matched: found }) => found === matched))
+      continue;
+
+    let content: MarkdownContent;
+    switch (type) {
+      case 'image':
+        content = {
+          type: 'image',
+          alt: first,
+          src: second,
+        };
+        break;
+      case 'link':
+        content = {
+          type: 'link',
+          content: first,
+          href: second,
+        };
+        break;
+      default:
+        throw new Error(
+          `Unknown type '${type}' specified for matchRichContent`,
+        );
+    }
+    result.push({ matched, content });
+  }
+
+  return result;
+}

--- a/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.ts
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/match-rich-content.ts
@@ -5,7 +5,7 @@ import { regexPatterns } from '../helper-fns/regex-patterns';
 
 export function matchRichContent(
   type: RichContentType,
-  content: string,
+  rawContent: string,
 ): MatchedContent[] {
   const pattern = regexPatterns[type];
   const result: MatchedContent[] = [];
@@ -13,7 +13,7 @@ export function matchRichContent(
     return result;
   }
 
-  const matches = content.matchAll(new RegExp(pattern, 'g'));
+  const matches = rawContent.matchAll(new RegExp(pattern, 'g'));
   if (!matches) {
     return result;
   }

--- a/ts-libs/markdown-parser/src/lib/reader-fns/read-paragraph.spec.ts
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/read-paragraph.spec.ts
@@ -1,7 +1,17 @@
+import { MarkdownContent } from '../models';
+import { lineHas } from '../helper-fns';
+import { matchRichContent } from './match-rich-content';
 import { readParagraph } from './read-paragraph';
+
+jest.mock('./match-rich-content');
+jest.mock('../helper-fns');
 
 describe('readParagraph', () => {
   describe('when line is plain text', () => {
+    beforeEach(() => {
+      jest.mocked(lineHas).mockReturnValue(false);
+    });
+
     it('should return expected content', () => {
       const lines = ['', 'Some content', ''];
       const start = 1;
@@ -12,6 +22,185 @@ describe('readParagraph', () => {
           content: 'Some content',
         },
         nextStart: 1,
+      });
+    });
+  });
+
+  describe('when line has rich content', () => {
+    describe('with link and image combined', () => {
+      it('should use readRichParagraph', () => {
+        const lines = ['', 'a bc c d', ''];
+        const lineHasSpy = jest.mocked(lineHas).mockReturnValue(true);
+        const splitRichContentSpy = jest
+          .mocked(matchRichContent)
+          .mockReturnValue([]);
+        const matchRichContentSpy = jest
+          .mocked(matchRichContent)
+          .mockImplementation((type) => {
+            if (type === 'image') {
+              return [
+                {
+                  matched: 'c',
+                  content: {
+                    type: 'image',
+                    alt: 'alt-text',
+                    src: '/image',
+                  },
+                },
+              ];
+            }
+
+            return [
+              {
+                matched: 'b__image_0__',
+                content: {
+                  type: 'link',
+                  content: '__image_0__',
+                  href: '/link',
+                },
+              },
+            ];
+          });
+
+        // Act
+        const result = readParagraph(lines, 1);
+
+        expect(lineHasSpy).toHaveBeenCalledWith('image', 'a bc c d');
+        expect(matchRichContentSpy).toHaveBeenCalledWith('image', 'a bc c d');
+        expect(matchRichContentSpy).toHaveBeenCalledWith(
+          'link',
+          'a b__image_0__ __image_0__ d',
+        );
+        expect(splitRichContentSpy).toHaveBeenCalledWith(
+          'a __link_0__ __image_0__',
+          expect.any(Object),
+        );
+        expect(splitRichContentSpy).toHaveBeenCalledWith(
+          '__image_0__',
+          expect.any(Object),
+        );
+      });
+    });
+
+    describe('with link wrapped by text', () => {
+      it('should return expected content', () => {
+        const lines = ['', 'a [text](/link) d', ''];
+        const lineHasSpy = jest
+          .mocked(lineHas)
+          .mockImplementation((t) => t === 'link');
+        const matchRichContentSpy = jest
+          .mocked(matchRichContent)
+          .mockReturnValue([
+            {
+              matched: '[text](/link)',
+              content: {
+                type: 'link',
+                content: 'text',
+                href: '/link',
+              },
+            },
+          ]);
+
+        // Act
+        const result = readParagraph(lines, 1);
+
+        expect(matchRichContentSpy).not.toHaveBeenCalledWith(
+          'image',
+          expect.any(String),
+        );
+        expect(lineHasSpy).toHaveBeenCalledWith('link', 'a [text](/link) d');
+        expect(matchRichContentSpy).toHaveBeenCalledWith(
+          'link',
+          'a [text](/link) d',
+        );
+        const expectedContent: MarkdownContent = {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'paragraph',
+              content: 'a ',
+            },
+            {
+              type: 'link',
+              content: 'text',
+              href: '/link',
+            },
+            {
+              type: 'paragraph',
+              content: ' d',
+            },
+          ],
+        };
+        expect(result).toEqual({
+          content: expectedContent,
+          nextStart: 1,
+        });
+      });
+    });
+
+    describe('with multiple images', () => {
+      it('should return expected', () => {
+        const lines = ['', '![text](/image) ![other](/image)', ''];
+        const lineHasSpy = jest
+          .mocked(lineHas)
+          .mockImplementation((t) => t === 'image');
+        const readRichContentSpy = jest
+          .mocked(matchRichContent)
+          .mockImplementation((t) => {
+            if (t === 'image') {
+              return [
+                {
+                  matched: '![text](/image)',
+                  content: {
+                    type: 'image',
+                    alt: 'text',
+                    src: '/image',
+                  },
+                },
+                {
+                  matched: '![other](/image)',
+                  content: {
+                    type: 'image',
+                    alt: 'other',
+                    src: '/image',
+                  },
+                },
+              ];
+            }
+
+            return [];
+          });
+
+        // Act
+        const result = readParagraph(lines, 1);
+
+        expect(lineHasSpy).toHaveBeenCalledWith(
+          'image',
+          'a ![text](/image) ![other](/image) d',
+        );
+        expect(readRichContentSpy).toHaveBeenCalledWith(
+          'image',
+          'a ![text](/image) ![other](/image) d',
+        );
+        const expectedContent: MarkdownContent = {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'image',
+              alt: 'text',
+              src: '/image',
+            },
+            {
+              type: 'image',
+              alt: 'other',
+              src: '/image',
+            },
+          ],
+        };
+        expect(result).toEqual({
+          content: expectedContent,
+          nextStart: 1,
+        });
       });
     });
   });

--- a/ts-libs/markdown-parser/src/lib/reader-fns/read-paragraph.ts
+++ b/ts-libs/markdown-parser/src/lib/reader-fns/read-paragraph.ts
@@ -1,10 +1,43 @@
-import { ReadResult } from '../_models';
+import { MarkdownContent, RichContentType } from '../models';
+import { MatchedContent, ReadResult } from '../_models';
+import { lineHas, splitRichContent } from '../helper-fns';
+
+import { matchRichContent } from './match-rich-content';
 
 export function readParagraph(lines: string[], start: number): ReadResult {
+  let line = lines[start];
+  if (!lineHas('image', line) && !lineHas('link', line)) {
+    return {
+      content: {
+        type: 'paragraph',
+        content: line,
+      },
+      nextStart: start,
+    };
+  }
+
+  const content: MarkdownContent[] = [];
+  const richContent: { [key: string]: MatchedContent } = {};
+  const contentTypes: RichContentType[] = ['image', 'link'];
+  for (const type of contentTypes) {
+    const richContentMatches = matchRichContent(type, line);
+    let typeCount = 0;
+    for (const { matched, content } of richContentMatches) {
+      const key = `__${type}_${typeCount++}__`;
+      richContent[key] = { matched, content };
+      line = line.replace(new RegExp(`(${matched})`, 'g'), key);
+    }
+  }
+
+  for (const { content } of Object.values(richContent)) {
+    if (content.type !== 'link' || Array.isArray(content.content)) continue;
+    content.content = splitRichContent(content.content, richContent);
+  }
+
   return {
     content: {
       type: 'paragraph',
-      content: lines[start],
+      content: splitRichContent(line, richContent),
     },
     nextStart: start,
   };

--- a/ts-libs/markdown-parser/src/lib/test-mds/image-and-link.md
+++ b/ts-libs/markdown-parser/src/lib/test-mds/image-and-link.md
@@ -1,0 +1,3 @@
+# Test link and image
+
+This is a [link](/link) and this is an ![image](/image).

--- a/ts-libs/markdown-parser/src/lib/test-mds/image-only.md
+++ b/ts-libs/markdown-parser/src/lib/test-mds/image-only.md
@@ -1,0 +1,3 @@
+# Line with only image
+
+![image](/image)

--- a/ts-libs/markdown-parser/src/lib/test-mds/link-only.md
+++ b/ts-libs/markdown-parser/src/lib/test-mds/link-only.md
@@ -1,0 +1,3 @@
+# Line with only link
+
+[link](/link)

--- a/ts-libs/markdown-parser/src/lib/test-mds/link-with-image.md
+++ b/ts-libs/markdown-parser/src/lib/test-mds/link-with-image.md
@@ -1,0 +1,3 @@
+# Image as link content
+
+[![image](/image)](/link)


### PR DESCRIPTION
Still a ways to go with this, but can give a whirl at a renderer for these objects soon and possibly reset how pages are shown.