### PR TITLE
Show secondary header after introduction

### DIFF
--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -131,6 +131,10 @@ jobs:
     name: '🧪 🚀'
     needs:
       - deploy_app
+    if: |
+      always() &&
+      needs.deploy_app.result == 'success' &&
+      github.event.action != 'closed'
     with:
       deployment_url: ${{ needs.deploy_app.outputs.deployed_url }}
       audit_urls: |

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -70,7 +70,10 @@ jobs:
       - lint_test_build
       - infra
     if: |
-      needs.lint_test_build.outputs.uploaded_artifacts == 'Yes' && github.event.action != 'closed'
+      always() &&
+      (needs.prep.outputs.infra_affected == 'No' || needs.infra.result == 'success') &&
+      needs.lint_test_build.outputs.uploaded_artifacts == 'Yes' &&
+      github.event.action != 'closed'
     runs-on: ubuntu-latest
     name: 'Deploy app 🚀'
     steps:

--- a/apps/blog/src/app/app.component.html
+++ b/apps/blog/src/app/app.component.html
@@ -1,42 +1,4 @@
-<header class="primary-block pj-header content">
-  <div class="pj-header-title content">
-    <div class="pj-header-title-logo">
-      <img
-        ngSrc="assets/logo-150.webp"
-        alt="logo"
-        height="150"
-        width="150"
-        [priority]="true"
-      />
-    </div>
-    <div class="pj-header-title-heading">
-      <h1>Peter Jokumsen</h1>
-      <h2 class="alt-text">An intentional software developer</h2>
-      <p>
-        <fa-icon class="mr-2" [icon]="codeIcon" aria-label="Code"></fa-icon>
-        using
-        <img
-          class="mx-2"
-          ngSrc="assets/icons/c-sharp.svg"
-          width="32"
-          height="32"
-          alt="C#"
-          aria-label="C Sharp"
-        />
-        &amp;
-        <img
-          class="ml-2"
-          ngSrc="assets/icons/typescript.svg"
-          width="32"
-          height="32"
-          alt="Typescript"
-          aria-label="Typescript"
-        />
-      </p>
-    </div>
-  </div>
-  <pj-ui-router-nav [routes]="navElements"></pj-ui-router-nav>
-</header>
+<app-header [navElements]="navElements" />
 <div class="main-block">
   <div class="content min-h-screen">
     <router-outlet></router-outlet>

--- a/apps/blog/src/app/app.component.spec.ts
+++ b/apps/blog/src/app/app.component.spec.ts
@@ -9,6 +9,9 @@ import { AppComponent } from './app.component';
 import { FooterComponent } from './components/footer';
 import { HeaderComponent } from './components/header';
 import { MockComponent } from 'ng-mocks';
+import { PjBrowserTools } from '@peterjokumsen/ng-services';
+import { Router } from '@angular/router';
+import { of } from 'rxjs';
 
 describe(`[blog] - ${AppComponent.name}`, () => {
   let fixture: ComponentFixture<AppComponent>;
@@ -17,6 +20,10 @@ describe(`[blog] - ${AppComponent.name}`, () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [AppComponent],
+      providers: [
+        { provide: PjBrowserTools, useValue: {} },
+        { provide: Router, useValue: { events: of() } },
+      ],
     })
       .overrideComponent(AppComponent, {
         remove: {

--- a/apps/blog/src/app/app.component.spec.ts
+++ b/apps/blog/src/app/app.component.spec.ts
@@ -7,6 +7,7 @@ import {
 
 import { AppComponent } from './app.component';
 import { FooterComponent } from './components/footer';
+import { HeaderComponent } from './components/header';
 import { MockComponent } from 'ng-mocks';
 
 describe(`[blog] - ${AppComponent.name}`, () => {
@@ -23,6 +24,7 @@ describe(`[blog] - ${AppComponent.name}`, () => {
             RouterNavComponent,
             FooterComponent,
             FullPageLoaderComponent,
+            HeaderComponent,
           ],
         },
         add: {
@@ -30,6 +32,7 @@ describe(`[blog] - ${AppComponent.name}`, () => {
             MockComponent(RouterNavComponent),
             MockComponent(ThemeToggleComponent),
             MockComponent(FooterComponent),
+            MockComponent(HeaderComponent),
           ],
         },
       })

--- a/apps/blog/src/app/app.component.ts
+++ b/apps/blog/src/app/app.component.ts
@@ -9,8 +9,8 @@ import { Route, RouterOutlet } from '@angular/router';
 
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { FooterComponent } from './components/footer';
+import { HeaderComponent } from './components/header';
 import { appRoutes } from './app.routes';
-import { faCode } from '@fortawesome/free-solid-svg-icons';
 import { pjFilterMap } from '@peterjokumsen/ts-utils';
 
 @Component({
@@ -23,6 +23,7 @@ import { pjFilterMap } from '@peterjokumsen/ts-utils';
     FullPageLoaderComponent,
     NgTemplateOutlet,
     FooterComponent,
+    HeaderComponent,
   ],
   selector: 'app-root',
   templateUrl: './app.component.html',
@@ -30,7 +31,6 @@ import { pjFilterMap } from '@peterjokumsen/ts-utils';
 })
 export class AppComponent implements OnInit {
   readonly navElements: PjUiRouterNavigationElement[] = [];
-  codeIcon = faCode;
 
   private createNavElement(route: Route): PjUiRouterNavigationElement {
     return {

--- a/apps/blog/src/app/app.config.ts
+++ b/apps/blog/src/app/app.config.ts
@@ -1,5 +1,10 @@
 import { ApplicationConfig, isDevMode } from '@angular/core';
 import {
+  PreloadAllModules,
+  provideRouter,
+  withPreloading,
+} from '@angular/router';
+import {
   providePjArticleParser,
   providePjBrowserTools,
   providePjHttpTools,
@@ -10,7 +15,6 @@ import {
 import { appRoutes } from './app.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideClientHydration } from '@angular/platform-browser';
-import { provideRouter } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { withFetch } from '@angular/common/http';
 
@@ -20,7 +24,7 @@ export const appConfig: ApplicationConfig = {
   providers: [
     provideAnimationsAsync(),
     provideClientHydration(),
-    provideRouter(appRoutes),
+    provideRouter(appRoutes, withPreloading(PreloadAllModules)),
     providePjHttpTools(config, withFetch()),
     providePjLogger(config),
     providePjTheme(),

--- a/apps/blog/src/app/app.config.ts
+++ b/apps/blog/src/app/app.config.ts
@@ -1,8 +1,10 @@
 import { ApplicationConfig, isDevMode } from '@angular/core';
 import {
   providePjArticleParser,
+  providePjBrowserTools,
   providePjHttpTools,
   providePjLogger,
+  providePjTheme,
 } from '@peterjokumsen/ng-services';
 
 import { appRoutes } from './app.routes';
@@ -21,10 +23,12 @@ export const appConfig: ApplicationConfig = {
     provideRouter(appRoutes),
     providePjHttpTools(config, withFetch()),
     providePjLogger(config),
+    providePjTheme(),
     provideServiceWorker('ngsw-worker.js', {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000',
     }),
     providePjArticleParser(),
+    providePjBrowserTools(),
   ],
 };

--- a/apps/blog/src/app/components/change-history/change-history.component.html
+++ b/apps/blog/src/app/components/change-history/change-history.component.html
@@ -1,18 +1,1 @@
 <pj-ui-article [sections]="sections()"></pj-ui-article>
-
-<mat-card>
-  <mat-card-header>
-    <h2>Created a Markdown parser</h2>
-  </mat-card-header>
-
-  <mat-card-content>
-    <p>Used to generate the following object:</p>
-
-    <pre><code>{{ parsed | json }}</code></pre>
-
-    <p>
-      To be used in a service in the future, but this is more about testing for
-      now. And will need to adjust rendering to use the end result.
-    </p>
-  </mat-card-content>
-</mat-card>

--- a/apps/blog/src/app/components/change-history/change-history.component.ts
+++ b/apps/blog/src/app/components/change-history/change-history.component.ts
@@ -4,24 +4,16 @@ import {
   computed,
   inject,
 } from '@angular/core';
-import { MatCard, MatCardContent, MatCardHeader } from '@angular/material/card';
 
 import { ArticleComponent } from '@peterjokumsen/ui-elements';
 import { CommonModule } from '@angular/common';
 import { PjArticleParser } from '@peterjokumsen/ng-services';
-import { parseMarkdown } from '@peterjokumsen/md-parser';
 import { toSignal } from '@angular/core/rxjs-interop';
 
 @Component({
   selector: 'app-change-history',
   standalone: true,
-  imports: [
-    CommonModule,
-    ArticleComponent,
-    MatCard,
-    MatCardHeader,
-    MatCardContent,
-  ],
+  imports: [CommonModule, ArticleComponent],
   templateUrl: './change-history.component.html',
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -42,5 +34,4 @@ There are quite a number of pieces I would like to get in place to complete this
 
   article = toSignal(this._parser.fromSource(this._markdown));
   sections = computed(() => this.article()?.sections ?? []);
-  parsed = parseMarkdown(this._markdown);
 }

--- a/apps/blog/src/app/components/footer/footer.component.spec.ts
+++ b/apps/blog/src/app/components/footer/footer.component.spec.ts
@@ -20,11 +20,11 @@ describe(FooterComponent.name, () => {
 
     await TestBed.configureTestingModule({
       imports: [FooterComponent],
+      providers: [{ provide: PjTheme, useValue: themeSpy }],
     })
       .overrideComponent(FooterComponent, {
         set: {
           imports: [MockComponent(ThemeToggleComponent)],
-          providers: [{ provide: PjTheme, useValue: themeSpy }],
         },
       })
       .compileComponents();

--- a/apps/blog/src/app/components/footer/footer.component.ts
+++ b/apps/blog/src/app/components/footer/footer.component.ts
@@ -4,13 +4,9 @@ import {
   OnInit,
   inject,
 } from '@angular/core';
-import {
-  PjTheme,
-  providePjBrowserTools,
-  providePjTheme,
-} from '@peterjokumsen/ng-services';
 
 import { CommonModule } from '@angular/common';
+import { PjTheme } from '@peterjokumsen/ng-services';
 import { ThemeToggleComponent } from '@peterjokumsen/ui-elements';
 import { toSignal } from '@angular/core/rxjs-interop';
 
@@ -18,7 +14,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
   selector: 'app-footer',
   standalone: true,
   imports: [CommonModule, ThemeToggleComponent],
-  providers: [providePjBrowserTools(), providePjTheme()],
+  providers: [],
   template: `
     <footer class="pj-footer primary-block">
       <div class="footer-top-left col-span-4 md:col-span-2"></div>

--- a/apps/blog/src/app/components/header/header.component.html
+++ b/apps/blog/src/app/components/header/header.component.html
@@ -1,0 +1,71 @@
+<header #primaryHeader class="primary-block pj-header content">
+  <div class="pj-header-title content">
+    <div class="pj-header-title-logo">
+      <img
+        [ngSrc]="imageSrc"
+        alt="logo"
+        height="150"
+        width="150"
+        [priority]="true"
+      />
+    </div>
+    <div class="pj-header-title-heading">
+      <h1>Peter Jokumsen</h1>
+      <h2 class="alt-text">An intentional software developer</h2>
+      <p>
+        <fa-icon class="mr-2" [icon]="codeIcon" aria-label="Code"></fa-icon>
+        using
+        <img
+          class="mx-2"
+          ngSrc="assets/icons/c-sharp.svg"
+          width="32"
+          height="32"
+          alt="C#"
+          aria-label="C Sharp"
+        />
+        &amp;
+        <img
+          class="ml-2"
+          ngSrc="assets/icons/typescript.svg"
+          width="32"
+          height="32"
+          alt="Typescript"
+          aria-label="Typescript"
+        />
+      </p>
+    </div>
+  </div>
+  <pj-ui-router-nav [routes]="navElements()"></pj-ui-router-nav>
+</header>
+@defer {
+  @if (windowPastHeader()) {
+    <div @showHide class="static-header">
+      <button
+        type="button"
+        class="secondary-header m-3"
+        mat-fab
+        extended="extended"
+        color="primary"
+        (click)="expanded = !expanded"
+      >
+        <div class="flex items-center justify-around">
+          <img [ngSrc]="imageSrc" alt="logo" height="60" width="60" />
+          <div class="pl-2 pr-5 font-bold">Peter Jokumsen</div>
+          <fa-icon [@rotateExpanded]="expanded" [icon]="chevronIcon"></fa-icon>
+        </div>
+      </button>
+
+      <div class="flex justify-center">
+        @if (expanded) {
+          <pj-ui-router-nav
+            @expandOrCollapse
+            [routes]="navElements()"
+            flexDirection="col"
+            flexAlign="center"
+            flexJustify="center"
+          ></pj-ui-router-nav>
+        }
+      </div>
+    </div>
+  }
+}

--- a/apps/blog/src/app/components/header/header.component.html
+++ b/apps/blog/src/app/components/header/header.component.html
@@ -1,4 +1,8 @@
-<header #primaryHeader class="primary-block pj-header content">
+<header
+  #primaryHeader
+  class="primary-block pj-header content"
+  (window:scroll)="onScroll()"
+>
   <div class="pj-header-title content">
     <div class="pj-header-title-logo">
       <img
@@ -46,26 +50,29 @@
         mat-fab
         extended="extended"
         color="primary"
-        (click)="expanded = !expanded"
+        [matMenuTriggerFor]="navMenu"
       >
         <div class="flex items-center justify-around">
           <img [ngSrc]="imageSrc" alt="logo" height="60" width="60" />
-          <div class="pl-2 pr-5 font-bold">Peter Jokumsen</div>
-          <fa-icon [@rotateExpanded]="expanded" [icon]="chevronIcon"></fa-icon>
+          <div class="pl-2 font-bold">Peter Jokumsen</div>
         </div>
       </button>
 
-      <div class="flex justify-center">
-        @if (expanded) {
-          <pj-ui-router-nav
-            @expandOrCollapse
-            [routes]="navElements()"
-            flexDirection="col"
-            flexAlign="center"
-            flexJustify="center"
-          ></pj-ui-router-nav>
+      <mat-menu #navMenu="matMenu" [xPosition]="'before'">
+        @for (nav of navElements(); track nav.route) {
+          <a
+            mat-menu-item
+            [routerLink]="nav.route"
+            routerLinkActive="is-active"
+            [routerLinkActiveOptions]="{ exact: nav.route === '' }"
+            ariaCurrentWhenActive="page"
+            #rla="routerLinkActive"
+            [disabled]="rla.isActive"
+          >
+            {{ nav.title }}
+          </a>
         }
-      </div>
+      </mat-menu>
     </div>
   }
 }

--- a/apps/blog/src/app/components/header/header.component.spec.ts
+++ b/apps/blog/src/app/components/header/header.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { HeaderComponent } from './header.component';
+
+describe('HeaderComponent', () => {
+  let component: HeaderComponent;
+  let fixture: ComponentFixture<HeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [HeaderComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(HeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/apps/blog/src/app/components/header/header.component.spec.ts
+++ b/apps/blog/src/app/components/header/header.component.spec.ts
@@ -1,6 +1,11 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MockComponent, MockDirective } from 'ng-mocks';
 
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { HeaderComponent } from './header.component';
+import { NgOptimizedImage } from '@angular/common';
+import { RouterNavComponent } from '@peterjokumsen/ui-elements';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
@@ -9,7 +14,18 @@ describe('HeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [HeaderComponent],
-    }).compileComponents();
+      schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    })
+      .overrideComponent(HeaderComponent, {
+        set: {
+          imports: [
+            MockComponent(RouterNavComponent),
+            MockComponent(FaIconComponent),
+            MockDirective(NgOptimizedImage),
+          ],
+        },
+      })
+      .compileComponents();
 
     fixture = TestBed.createComponent(HeaderComponent);
     component = fixture.componentInstance;

--- a/apps/blog/src/app/components/header/header.component.spec.ts
+++ b/apps/blog/src/app/components/header/header.component.spec.ts
@@ -5,15 +5,24 @@ import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
 import { HeaderComponent } from './header.component';
 import { NgOptimizedImage } from '@angular/common';
+import { PjBrowserTools } from '@peterjokumsen/ng-services';
 import { RouterNavComponent } from '@peterjokumsen/ui-elements';
 
 describe('HeaderComponent', () => {
   let component: HeaderComponent;
   let fixture: ComponentFixture<HeaderComponent>;
+  let browserToolsSpy: Partial<jest.Mocked<PjBrowserTools>>;
 
   beforeEach(async () => {
+    browserToolsSpy = {
+      window: {} as unknown as Window,
+    };
     await TestBed.configureTestingModule({
       imports: [HeaderComponent],
+      providers: [
+        // keep split
+        { provide: PjBrowserTools, useValue: browserToolsSpy },
+      ],
       schemas: [CUSTOM_ELEMENTS_SCHEMA],
     })
       .overrideComponent(HeaderComponent, {
@@ -34,5 +43,11 @@ describe('HeaderComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('onScroll', () => {
+    it('should no throw error', () => {
+      expect(() => component.onScroll()).not.toThrow();
+    });
   });
 });

--- a/apps/blog/src/app/components/header/header.component.ts
+++ b/apps/blog/src/app/components/header/header.component.ts
@@ -1,12 +1,30 @@
-import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  ElementRef,
+  HostListener,
+  ViewChild,
+  inject,
+  input,
+  signal,
+} from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { PjBrowserTools, PjLogger } from '@peterjokumsen/ng-services';
 import {
   PjUiRouterNavigationElement,
   RouterNavComponent,
 } from '@peterjokumsen/ui-elements';
+import {
+  animate,
+  state,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+import { faChevronRight, faCode } from '@fortawesome/free-solid-svg-icons';
 
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { faCode } from '@fortawesome/free-solid-svg-icons';
+import { MatFabButton } from '@angular/material/button';
 
 @Component({
   selector: 'app-header',
@@ -16,52 +34,76 @@ import { faCode } from '@fortawesome/free-solid-svg-icons';
     FaIconComponent,
     NgOptimizedImage,
     RouterNavComponent,
+    MatFabButton,
   ],
-  template: `
-    <header class="primary-block pj-header content">
-      <div class="pj-header-title content">
-        <div class="pj-header-title-logo">
-          <img
-            ngSrc="assets/logo-150.webp"
-            alt="logo"
-            height="150"
-            width="150"
-            [priority]="true"
-          />
-        </div>
-        <div class="pj-header-title-heading">
-          <h1>Peter Jokumsen</h1>
-          <h2 class="alt-text">An intentional software developer</h2>
-          <p>
-            <fa-icon class="mr-2" [icon]="codeIcon" aria-label="Code"></fa-icon>
-            using
-            <img
-              class="mx-2"
-              ngSrc="assets/icons/c-sharp.svg"
-              width="32"
-              height="32"
-              alt="C#"
-              aria-label="C Sharp"
-            />
-            &amp;
-            <img
-              class="ml-2"
-              ngSrc="assets/icons/typescript.svg"
-              width="32"
-              height="32"
-              alt="Typescript"
-              aria-label="Typescript"
-            />
-          </p>
-        </div>
-      </div>
-      <pj-ui-router-nav [routes]="navElements()"></pj-ui-router-nav>
-    </header>
+  templateUrl: './header.component.html',
+  styles: `
+    .static-header {
+      position: fixed;
+      top: 0;
+    }
+
+    .secondary-header {
+      height: 70px;
+    }
   `,
-  styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  animations: [
+    trigger('showHide', [
+      transition(':enter', [
+        style({ transform: 'translateX(-100%)' }),
+        animate('0.4s', style({ transform: 'translateX(0)' })),
+      ]),
+      transition(':leave', [
+        animate('300ms', style({ transform: 'translateX(-100%)' })),
+      ]),
+    ]),
+    trigger('expandOrCollapse', [
+      transition(':enter', [
+        style({ transform: 'translateX(-100%)' }),
+        animate('0.4s', style({ transform: 'translateX(0)' })),
+      ]),
+      transition(':leave', [
+        animate('300ms', style({ transform: 'translateX(-100%)' })),
+      ]),
+    ]),
+    trigger('rotateExpanded', [
+      state('true', style({ transform: 'rotate(180deg)' })),
+      state('false', style({ transform: 'rotate(0deg)' })),
+      transition('true <=> false', animate('0.4s')),
+    ]),
+  ],
 })
 export class HeaderComponent {
+  private _logger = inject(PjLogger, { optional: true });
+  private _browserTools = inject(PjBrowserTools, { optional: true });
+
+  imageSrc = 'assets/logo-150.webp';
+  windowPastHeader = signal<boolean>(false);
+
   codeIcon = faCode;
   navElements = input<PjUiRouterNavigationElement[]>([]);
+
+  expanded = false;
+  chevronIcon = faChevronRight;
+
+  @ViewChild('primaryHeader', { static: true }) primaryHeader?: ElementRef;
+
+  @HostListener('window:scroll')
+  onScroll() {
+    const windowScrollY = this._browserTools?.window?.scrollY ?? 0;
+    const documentHeight =
+      this._browserTools?.window?.document?.documentElement.clientHeight ?? 0;
+    const headerHeight = this.primaryHeader?.nativeElement.clientHeight ?? 0;
+    const pastHeader = windowScrollY > documentHeight + headerHeight;
+    if (this.windowPastHeader() !== pastHeader) {
+      this._logger?.to.log(
+        'Window: %s, Document: %s, Header: %s',
+        windowScrollY,
+        documentHeight,
+        headerHeight,
+      );
+      this.windowPastHeader.update(() => pastHeader);
+    }
+  }
 }

--- a/apps/blog/src/app/components/header/header.component.ts
+++ b/apps/blog/src/app/components/header/header.component.ts
@@ -103,6 +103,10 @@ export class HeaderComponent {
         documentHeight,
         headerHeight,
       );
+      if (!pastHeader) {
+        this.expanded = false;
+      }
+
       this.windowPastHeader.update(() => pastHeader);
     }
   }

--- a/apps/blog/src/app/components/header/header.component.ts
+++ b/apps/blog/src/app/components/header/header.component.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import {
+  PjUiRouterNavigationElement,
+  RouterNavComponent,
+} from '@peterjokumsen/ui-elements';
+
+import { FaIconComponent } from '@fortawesome/angular-fontawesome';
+import { faCode } from '@fortawesome/free-solid-svg-icons';
+
+@Component({
+  selector: 'app-header',
+  standalone: true,
+  imports: [
+    CommonModule,
+    FaIconComponent,
+    NgOptimizedImage,
+    RouterNavComponent,
+  ],
+  template: `
+    <header class="primary-block pj-header content">
+      <div class="pj-header-title content">
+        <div class="pj-header-title-logo">
+          <img
+            ngSrc="assets/logo-150.webp"
+            alt="logo"
+            height="150"
+            width="150"
+            [priority]="true"
+          />
+        </div>
+        <div class="pj-header-title-heading">
+          <h1>Peter Jokumsen</h1>
+          <h2 class="alt-text">An intentional software developer</h2>
+          <p>
+            <fa-icon class="mr-2" [icon]="codeIcon" aria-label="Code"></fa-icon>
+            using
+            <img
+              class="mx-2"
+              ngSrc="assets/icons/c-sharp.svg"
+              width="32"
+              height="32"
+              alt="C#"
+              aria-label="C Sharp"
+            />
+            &amp;
+            <img
+              class="ml-2"
+              ngSrc="assets/icons/typescript.svg"
+              width="32"
+              height="32"
+              alt="Typescript"
+              aria-label="Typescript"
+            />
+          </p>
+        </div>
+      </div>
+      <pj-ui-router-nav [routes]="navElements()"></pj-ui-router-nav>
+    </header>
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class HeaderComponent {
+  codeIcon = faCode;
+  navElements = input<PjUiRouterNavigationElement[]>([]);
+}

--- a/apps/blog/src/app/components/header/header.component.ts
+++ b/apps/blog/src/app/components/header/header.component.ts
@@ -2,39 +2,40 @@ import {
   ChangeDetectionStrategy,
   Component,
   ElementRef,
-  HostListener,
   ViewChild,
   inject,
   input,
   signal,
 } from '@angular/core';
 import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { MatAnchor, MatFabButton } from '@angular/material/button';
+import { MatMenu, MatMenuItem, MatMenuTrigger } from '@angular/material/menu';
 import { PjBrowserTools, PjLogger } from '@peterjokumsen/ng-services';
 import {
   PjUiRouterNavigationElement,
   RouterNavComponent,
 } from '@peterjokumsen/ui-elements';
-import {
-  animate,
-  state,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
-import { faChevronRight, faCode } from '@fortawesome/free-solid-svg-icons';
+import { RouterLink, RouterLinkActive } from '@angular/router';
+import { animate, style, transition, trigger } from '@angular/animations';
 
 import { FaIconComponent } from '@fortawesome/angular-fontawesome';
-import { MatFabButton } from '@angular/material/button';
+import { faCode } from '@fortawesome/free-solid-svg-icons';
 
 @Component({
   selector: 'app-header',
   standalone: true,
   imports: [
     CommonModule,
-    FaIconComponent,
     NgOptimizedImage,
     RouterNavComponent,
     MatFabButton,
+    MatMenu,
+    MatMenuItem,
+    RouterLink,
+    MatAnchor,
+    RouterLinkActive,
+    MatMenuTrigger,
+    FaIconComponent,
   ],
   templateUrl: './header.component.html',
   styles: `
@@ -58,20 +59,6 @@ import { MatFabButton } from '@angular/material/button';
         animate('300ms', style({ transform: 'translateX(-100%)' })),
       ]),
     ]),
-    trigger('expandOrCollapse', [
-      transition(':enter', [
-        style({ transform: 'translateX(-100%)' }),
-        animate('0.4s', style({ transform: 'translateX(0)' })),
-      ]),
-      transition(':leave', [
-        animate('300ms', style({ transform: 'translateX(-100%)' })),
-      ]),
-    ]),
-    trigger('rotateExpanded', [
-      state('true', style({ transform: 'rotate(180deg)' })),
-      state('false', style({ transform: 'rotate(0deg)' })),
-      transition('true <=> false', animate('0.4s')),
-    ]),
   ],
 })
 export class HeaderComponent {
@@ -84,12 +71,8 @@ export class HeaderComponent {
   codeIcon = faCode;
   navElements = input<PjUiRouterNavigationElement[]>([]);
 
-  expanded = false;
-  chevronIcon = faChevronRight;
-
   @ViewChild('primaryHeader', { static: true }) primaryHeader?: ElementRef;
 
-  @HostListener('window:scroll')
   onScroll() {
     const windowScrollY = this._browserTools?.window?.scrollY ?? 0;
     const documentHeight =
@@ -97,16 +80,6 @@ export class HeaderComponent {
     const headerHeight = this.primaryHeader?.nativeElement.clientHeight ?? 0;
     const pastHeader = windowScrollY > documentHeight + headerHeight;
     if (this.windowPastHeader() !== pastHeader) {
-      this._logger?.to.log(
-        'Window: %s, Document: %s, Header: %s',
-        windowScrollY,
-        documentHeight,
-        headerHeight,
-      );
-      if (!pastHeader) {
-        this.expanded = false;
-      }
-
       this.windowPastHeader.update(() => pastHeader);
     }
   }

--- a/apps/blog/src/app/components/header/index.ts
+++ b/apps/blog/src/app/components/header/index.ts
@@ -1,0 +1,1 @@
+export * from './header.component';

--- a/ng-libs/services/src/lib/pj-article-parser/pj-article-parser.service.ts
+++ b/ng-libs/services/src/lib/pj-article-parser/pj-article-parser.service.ts
@@ -9,20 +9,16 @@ export class PjArticleParser {
   private _logger = inject(PjLogger, { optional: true });
 
   fromSource(source: string): Observable<PjArticle> {
-    this._logger?.to.group('PJ Article Parser');
     const parsedResult: PjArticle = {
       sections: [],
     };
     let content: PjArticleContent = [];
     for (const rawLine of source.split('\n').reverse()) {
       const line = rawLine?.trimStart();
-      this._logger?.to.log('rawLine: "%s"', rawLine);
-      this._logger?.to.log('line: "%s"', line);
       if (line.startsWith('# ')) {
         parsedResult.title = line.replace('# ', '');
         parsedResult.introduction = [...content.reverse()];
         parsedResult.sections.reverse();
-        this._logger?.to.log('found title: %s', parsedResult.title);
         break;
       }
 
@@ -44,8 +40,6 @@ export class PjArticleParser {
       }
     }
 
-    this._logger?.to.log('parseResult: %o', parsedResult);
-    this._logger?.to.groupEnd();
     return of(parsedResult);
   }
 }

--- a/ng-libs/ui-elements/src/lib/article/article-nav/article-nav.component.html
+++ b/ng-libs/ui-elements/src/lib/article/article-nav/article-nav.component.html
@@ -6,32 +6,30 @@
     #content
     class="col-span-5 md:col-span-3 md:col-start-1 lg:col-span-2 lg:col-start-2"
   >
-    <div class="sticky top-2 col-span-5 md:hidden">
-      <div class="control m-5 flex justify-end">
-        <button
-          mat-mini-fab
-          type="button"
-          [matMenuTriggerFor]="navMenu"
-          [color]="'primary'"
-          aria-label="Show or hide page navigation"
-        >
-          <fa-icon [icon]="expandIcon"></fa-icon>
-        </button>
-        <mat-menu #navMenu="matMenu" [xPosition]="'before'">
-          @for (nav of navElements(); track nav.id) {
-            <button
-              mat-menu-item
-              type="button"
-              [disabled]="nav.id === inViewId()"
-              (click)="navigateClicked(nav)"
-            >
-              <ng-container
-                *ngTemplateOutlet="navElementTitleTemplate; context: { nav }"
-              ></ng-container>
-            </button>
-          }
-        </mat-menu>
-      </div>
+    <div class="sticky top-4 float-right m-4 inline-block md:hidden">
+      <button
+        mat-mini-fab
+        type="button"
+        [matMenuTriggerFor]="navMenu"
+        [color]="'primary'"
+        aria-label="Show or hide page navigation"
+      >
+        <fa-icon [icon]="expandIcon"></fa-icon>
+      </button>
+      <mat-menu #navMenu="matMenu" [xPosition]="'before'">
+        @for (nav of navElements(); track nav.id) {
+          <button
+            mat-menu-item
+            type="button"
+            [disabled]="nav.id === inViewId()"
+            (click)="navigateClicked(nav)"
+          >
+            <ng-container
+              *ngTemplateOutlet="navElementTitleTemplate; context: { nav }"
+            ></ng-container>
+          </button>
+        }
+      </mat-menu>
     </div>
     <ng-content></ng-content>
   </div>

--- a/ng-libs/ui-elements/src/lib/router-nav/models/flex-overrides.ts
+++ b/ng-libs/ui-elements/src/lib/router-nav/models/flex-overrides.ts
@@ -1,0 +1,9 @@
+export type FlexDirection = 'row' | 'col';
+export type FlexJustify =
+  | 'start'
+  | 'end'
+  | 'center'
+  | 'between'
+  | 'around'
+  | 'evenly';
+export type FlexAlign = 'start' | 'end' | 'center' | 'between' | 'around';

--- a/ng-libs/ui-elements/src/lib/router-nav/models/index.ts
+++ b/ng-libs/ui-elements/src/lib/router-nav/models/index.ts
@@ -1,1 +1,2 @@
+export * from './flex-overrides';
 export * from './pj-ui-router-navigation-element';

--- a/ng-libs/ui-elements/src/lib/router-nav/router-nav.component.spec.ts
+++ b/ng-libs/ui-elements/src/lib/router-nav/router-nav.component.spec.ts
@@ -1,22 +1,59 @@
+import { Component, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  FlexAlign,
+  FlexDirection,
+  FlexJustify,
+  PjUiRouterNavigationElement,
+} from './models';
 
+import { CommonModule } from '@angular/common';
+import { MockComponent } from 'ng-mocks';
 import { RouterNavComponent } from './router-nav.component';
+import { ThemeToggleComponent } from '../theme-toggle';
+
+@Component({
+  imports: [RouterNavComponent],
+  template: `
+    <pj-ui-router-nav
+      #navComponent
+      [routes]="routes"
+      [flexAlign]="flexAlign"
+      [flexJustify]="flexJustify"
+      [flexDirection]="flexDirection"
+    ></pj-ui-router-nav>
+  `,
+  standalone: true,
+})
+class RouterNavHostComponent {
+  @ViewChild('navComponent') navComponent!: RouterNavComponent;
+  routes: PjUiRouterNavigationElement[] = [];
+  flexAlign: FlexAlign = 'end';
+  flexJustify: FlexJustify = 'end';
+  flexDirection: FlexDirection = 'row';
+}
 
 describe('RouterNavComponent', () => {
-  let component: RouterNavComponent;
-  let fixture: ComponentFixture<RouterNavComponent>;
+  let hostComponent: RouterNavHostComponent;
+  let fixture: ComponentFixture<RouterNavHostComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [RouterNavComponent],
-    }).compileComponents();
+      imports: [RouterNavHostComponent],
+    })
+      .overrideComponent(RouterNavComponent, {
+        set: {
+          imports: [CommonModule, MockComponent(ThemeToggleComponent)],
+        },
+      })
+      .compileComponents();
 
-    fixture = TestBed.createComponent(RouterNavComponent);
-    component = fixture.componentInstance;
+    fixture = TestBed.createComponent(RouterNavHostComponent);
+    hostComponent = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
-    expect(component).toBeTruthy();
+    expect(hostComponent.navComponent).toBeTruthy();
   });
 });

--- a/ng-libs/ui-elements/src/lib/router-nav/router-nav.component.ts
+++ b/ng-libs/ui-elements/src/lib/router-nav/router-nav.component.ts
@@ -1,19 +1,48 @@
 import { ChangeDetectionStrategy, Component, input } from '@angular/core';
+import {
+  FlexAlign,
+  FlexDirection,
+  FlexJustify,
+  PjUiRouterNavigationElement,
+} from './models';
 import { RouterLink, RouterLinkActive } from '@angular/router';
 
 import { CommonModule } from '@angular/common';
 import { MatAnchor } from '@angular/material/button';
-import { PjUiRouterNavigationElement } from './models';
+import { ThemeToggleComponent } from '../theme-toggle';
 
 @Component({
   selector: 'pj-ui-router-nav',
   standalone: true,
-  imports: [CommonModule, RouterLinkActive, RouterLink, MatAnchor],
+  imports: [
+    CommonModule,
+    RouterLinkActive,
+    RouterLink,
+    MatAnchor,
+    ThemeToggleComponent,
+  ],
   template: `
     <ng-template #titleTemplate let-nav="navElement" let-isActive="isActive">
       <span [ngClass]="{ 'font-bold': isActive }"> {{ nav.title }} </span>
     </ng-template>
-    <nav class="flex flex-row items-end justify-end gap-2">
+    <nav
+      class="flex"
+      [ngClass]="{
+        'items-end': flexAlign() === 'end',
+        'items-center': flexAlign() === 'center',
+        'flex-row': flexDirection() === 'row',
+        'flex-col': flexDirection() === 'col',
+        'justify-end': flexJustify() === 'end',
+        'justify-center': flexJustify() === 'center',
+        'justify-between': flexJustify() === 'between',
+        'justify-around': flexJustify() === 'around',
+        'justify-evenly': flexJustify() === 'evenly',
+        'justify-start': flexJustify() === 'start',
+        'gap-1': flexGap() === 1,
+        'gap-2': flexGap() === 2,
+        'gap-3': flexGap() === 3
+      }"
+    >
       @for (navElement of routes(); track navElement.route) {
         <a
           mat-raised-button
@@ -21,6 +50,7 @@ import { PjUiRouterNavigationElement } from './models';
           [routerLink]="navElement.route"
           routerLinkActive="is-active"
           [routerLinkActiveOptions]="{ exact: isRootElement(navElement) }"
+          ariaCurrentWhenActive="page"
           #rla="routerLinkActive"
           [disabled]="rla.isActive"
         >
@@ -30,6 +60,7 @@ import { PjUiRouterNavigationElement } from './models';
           ></ng-container>
         </a>
       }
+      <pj-ui-theme-toggle></pj-ui-theme-toggle>
     </nav>
   `,
   styleUrl: 'router-nav.component.scss',
@@ -37,6 +68,10 @@ import { PjUiRouterNavigationElement } from './models';
 })
 export class RouterNavComponent {
   routes = input<PjUiRouterNavigationElement[]>([]);
+  flexDirection = input<FlexDirection>('row');
+  flexJustify = input<FlexJustify>('end');
+  flexAlign = input<FlexAlign>('end');
+  flexGap = input<0 | 1 | 2 | 3>(2);
 
   isRootElement(route: PjUiRouterNavigationElement) {
     return route.route === '/' || route.route === '';


### PR DESCRIPTION
## Summary

Updated to show header navigation throughout the component.

## Changes Made

- Updated router-nav component to allow for override the flex classes used, using `[ngClass]` to allow TailWind to include the necessary classes used.
- Created new header component in `blog` to render header, and updated it to show secondary header when screen goes past page introduction. Acts as a button that when clicked shows navigation for the site.
- Moved theme toggle component into router-nav to enable switching theme in header. Although initial size now over warning, but will create a new issue to try and minimize the initial build size.

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

## Related issues

Closes #72

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

</details>
<!-- End of Optional Sections -->
