### PR TITLE
Set theme in splash component

### DIFF
--- a/apps/blog/src/app/app.config.ts
+++ b/apps/blog/src/app/app.config.ts
@@ -1,9 +1,14 @@
 import { ApplicationConfig, isDevMode } from '@angular/core';
+import {
+  providePjBrowserTools,
+  providePjHttpTools,
+  providePjLogger,
+  providePjTheme,
+} from '@peterjokumsen/ng-services';
 
 import { appInitialRoutes } from './app-initial.routes';
 import { provideAnimationsAsync } from '@angular/platform-browser/animations/async';
 import { provideClientHydration } from '@angular/platform-browser';
-import { providePjHttpTools } from '@peterjokumsen/ng-services';
 import { provideRouter } from '@angular/router';
 import { provideServiceWorker } from '@angular/service-worker';
 import { withFetch } from '@angular/common/http';
@@ -17,6 +22,10 @@ export const appConfig: ApplicationConfig = {
       enabled: !isDevMode(),
       registrationStrategy: 'registerWhenStable:30000',
     }),
+
+    providePjBrowserTools(),
+    providePjLogger({ production: !isDevMode() }),
+    providePjTheme(),
     providePjHttpTools({ production: !isDevMode() }, withFetch()),
   ],
 };

--- a/apps/blog/src/app/app.routes.ts
+++ b/apps/blog/src/app/app.routes.ts
@@ -1,15 +1,6 @@
-import {
-  providePjArticleParser,
-  providePjBrowserTools,
-  providePjLogger,
-  providePjTheme,
-} from '@peterjokumsen/ng-services';
-
 import { PrimaryComponent } from './primary.component';
 import { Route } from '@angular/router';
-import { isDevMode } from '@angular/core';
-
-const config = { production: !isDevMode() };
+import { providePjArticleParser } from '@peterjokumsen/ng-services';
 
 export const childRoutes: Route[] = [
   {
@@ -43,11 +34,6 @@ export const appRoutes: Route[] = [
     path: '',
     component: PrimaryComponent,
     loadChildren: () => childRoutes,
-    providers: [
-      providePjArticleParser(),
-      providePjBrowserTools(),
-      providePjLogger(config),
-      providePjTheme(),
-    ],
+    providers: [providePjArticleParser()],
   },
 ];

--- a/apps/blog/src/app/splash.component.spec.ts
+++ b/apps/blog/src/app/splash.component.spec.ts
@@ -1,14 +1,22 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { PjTheme } from '@peterjokumsen/ng-services';
 import { SplashComponent } from './splash.component';
+import { of } from 'rxjs';
 
 describe('SplashComponent', () => {
   let component: SplashComponent;
   let fixture: ComponentFixture<SplashComponent>;
+  let themeSpy: Partial<jest.Mocked<PjTheme>>;
 
   beforeEach(async () => {
+    themeSpy = {
+      theme$: of('dark'),
+      setTheme: jest.fn(),
+    };
     await TestBed.configureTestingModule({
       imports: [SplashComponent],
+      providers: [{ provide: PjTheme, useValue: themeSpy }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(SplashComponent);
@@ -18,5 +26,9 @@ describe('SplashComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  it('should set theme', () => {
+    expect(themeSpy.setTheme).toHaveBeenCalledWith('dark');
   });
 });

--- a/apps/blog/src/app/splash.component.ts
+++ b/apps/blog/src/app/splash.component.ts
@@ -1,20 +1,20 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
-import { CommonModule, NgOptimizedImage } from '@angular/common';
 import {
-  animate,
-  keyframes,
-  style,
-  transition,
-  trigger,
-} from '@angular/animations';
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
+import { CommonModule, NgOptimizedImage } from '@angular/common';
+import { animate, style, transition, trigger } from '@angular/animations';
 
-import { PrimaryComponent } from './primary.component';
+import { PjTheme } from '@peterjokumsen/ng-services';
 import { RouterOutlet } from '@angular/router';
+import { first } from 'rxjs';
 
 @Component({
   standalone: true,
   selector: 'app-root',
-  imports: [CommonModule, RouterOutlet, NgOptimizedImage, PrimaryComponent],
+  imports: [CommonModule, RouterOutlet, NgOptimizedImage],
   animations: [
     trigger('fadeOut', [
       transition(':leave', [
@@ -23,17 +23,18 @@ import { RouterOutlet } from '@angular/router';
       ]),
     ]),
   ],
+  providers: [],
   template: `
     @defer {
       <router-outlet></router-outlet>
     } @loading (minimum 500ms) {
       <div @fadeOut class="splash">
         <img
-          @coinFlip
           ngSrc="/assets/logo-150.webp"
           width="150"
           height="150"
           alt="Splash logo"
+          [priority]="true"
         />
       </div>
     }
@@ -69,4 +70,12 @@ import { RouterOutlet } from '@angular/router';
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
-export class SplashComponent {}
+export class SplashComponent implements OnInit {
+  private _themeSvc = inject(PjTheme);
+
+  ngOnInit() {
+    this._themeSvc.theme$.pipe(first()).subscribe((theme) => {
+      this._themeSvc.setTheme(theme);
+    });
+  }
+}


### PR DESCRIPTION
## Summary

To try and fix flash of dark to light theme after primary component loaded, updated splash component to set theme.

## Changes Made

- Moved providers into `app.config.ts` to allow setting theme.
- Updated splash component to set first available theme.
- Looks like moving the providers around helped with initial load bundle size.

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

## Related issues

Related to #67 #86

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

Plan to test in PR workflow (Should be able to check on lighthouse reports)

</details>
<!-- End of Optional Sections -->
