### PR TITLE
fix(.github): adjust git commands to checkout `main`

### DIFF
--- a/.github/workflows/_workflow.jobs.lint_test_build_affected.yml
+++ b/.github/workflows/_workflow.jobs.lint_test_build_affected.yml
@@ -67,7 +67,7 @@ jobs:
 
       - name: 'Fetch main branch 🌿'
         run: |
-          git rev-parse --verify main || git remote set-branches origin main && git fetch --depth 1 origin main && git branch main origin/main
+          git rev-parse --verify main || (git remote set-branches origin main && git fetch --depth 1 origin main && git branch main origin/main)
 
       - name: 'Install dependencies 📦'
         uses: ./.github/actions/install-deps


### PR DESCRIPTION
Adjusted bash script to only checkout `main` when `rev-parse` command is falsy.

## Summary

<!-- Provide a concise summary "Why are the changes needed"?
Include any relevant links, such as Jira tickets, Slack discussions,
or design documents. -->

## Changes Made

<!-- Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem
and any notable implementation details. -->

-

## Checklist

- [ ] I have added comments to code in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

## Related issues

<!-- A link to any related issues or bugs that the pull request
addresses, connecting the code's context with the problem it
solves. -->

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

</details>
<!-- End of Optional Sections -->
