### PR TITLE
Update parser and renderer to handle inline code

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/index.ts
+++ b/ng-libs/md-renderer/src/lib/components/index.ts
@@ -1,3 +1,4 @@
+export * from './md-code.component';
 export * from './md-image.component';
 export * from './md-link.component';
 export * from './md-list.component';

--- a/ng-libs/md-renderer/src/lib/components/md-code.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code.component.spec.ts
@@ -1,0 +1,51 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogFns, PjLogger } from '@peterjokumsen/ng-services';
+
+import { MdCodeComponent } from './md-code.component';
+
+describe('MdCodeComponent', () => {
+  let component: MdCodeComponent;
+  let fixture: ComponentFixture<MdCodeComponent>;
+  let logSpy: Partial<jest.Mocked<LogFns>>;
+
+  beforeEach(async () => {
+    logSpy = {
+      warn: jest.fn().mockName('warn'),
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        // providers
+        { provide: PjLogger, useValue: { to: logSpy } },
+      ],
+      declarations: [MdCodeComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MdCodeComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('content', () => {
+    it('should extract element value', () => {
+      component.content = { type: 'code', element: 'value' };
+      expect(component.elementValue()).toEqual('value');
+    });
+
+    describe('when content is not a code element', () => {
+      it('should reset element value', () => {
+        component.elementValue.update(() => 'value');
+        component.content = 'value';
+        expect(component.elementValue()).toEqual('');
+        expect(logSpy.warn).toHaveBeenCalledWith(
+          'Invalid content for MdCodeComponent, received %o',
+          'value',
+        );
+      });
+    });
+  });
+});

--- a/ng-libs/md-renderer/src/lib/components/md-code.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code.component.ts
@@ -1,0 +1,46 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+
+import { HasContent } from '../has-content';
+import { PjLogger } from '@peterjokumsen/ng-services';
+
+@Component({
+  selector: 'pj-mdr-md-code',
+  template: `
+    @if (elementValue()) {
+      <span class="md-code">{{ elementValue() }}</span>
+    }
+  `,
+  styles: `
+    :host {
+      padding: 5px;
+      border-radius: 5px;
+      font-family: monospace, monospace;
+      border: 1px solid;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MdCodeComponent implements HasContent<'code'> {
+  private _logger = inject(PjLogger, { optional: true });
+
+  elementValue = signal('');
+
+  set content(value: HasContent<'code'>['content']) {
+    if (typeof value === 'string' || value.type !== 'code') {
+      this._logger?.to.warn(
+        'Invalid content for MdCodeComponent, received %o',
+        value,
+      );
+
+      this.elementValue.update(() => '');
+      return;
+    }
+
+    this.elementValue.update(() => value.element);
+  }
+}

--- a/ng-libs/md-renderer/src/lib/filter-content-types.ts
+++ b/ng-libs/md-renderer/src/lib/filter-content-types.ts
@@ -2,7 +2,7 @@ import { MarkdownContentType, MarkdownType } from '@peterjokumsen/ts-md-models';
 
 export type ExpectedContentTypes = Extract<
   MarkdownContentType,
-  'section' | 'paragraph' | 'link' | 'text' | 'image' | 'list'
+  'section' | 'paragraph' | 'link' | 'text' | 'image' | 'list' | 'code'
 >;
 
 const allowed: Required<Record<ExpectedContentTypes, object>> = {
@@ -12,6 +12,7 @@ const allowed: Required<Record<ExpectedContentTypes, object>> = {
   text: {},
   image: {},
   list: {},
+  code: {},
 };
 
 const allowedTypes = Object.keys(allowed) as ExpectedContentTypes[];

--- a/ng-libs/md-renderer/src/lib/md-components.module.ts
+++ b/ng-libs/md-renderer/src/lib/md-components.module.ts
@@ -10,6 +10,7 @@ import {
 import { ModuleWithProviders, NgModule } from '@angular/core';
 
 import { CommonModule } from '@angular/common';
+import { MdCodeComponent } from './components/md-code.component';
 import { MdContentInjectionDirective } from './directives/md-content-injection.directive';
 import { MdListComponent } from './components/md-list.component';
 import { MdTitleComponent } from './components/md-title.component';
@@ -27,6 +28,7 @@ import { MdTitleComponent } from './components/md-title.component';
     MdWrapperComponent,
 
     MdContentInjectionDirective,
+    MdCodeComponent,
   ],
   exports: [MdContentInjectionDirective, MdWrapperComponent],
 })

--- a/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
+++ b/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
@@ -2,6 +2,7 @@ import { HasContent, HasContentBase } from '../has-content';
 import { Injectable, Type, inject } from '@angular/core';
 import { MD_COMPONENT_TYPE_MAP, MdComponentTypeMap } from '../injection.tokens';
 import {
+  MdCodeComponent,
   MdImageComponent,
   MdLinkComponent,
   MdListComponent,
@@ -16,6 +17,7 @@ import { ExpectedContentTypes } from '../filter-content-types';
 export class MdComponentMapService {
   private _typeMap = inject(MD_COMPONENT_TYPE_MAP, { optional: true });
   private _defaultMap: MdComponentTypeMap = {
+    code: MdCodeComponent,
     paragraph: MdParagraphComponent,
     image: MdImageComponent,
     text: MdTextComponent,

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
@@ -11,6 +11,17 @@ interface Expectation<T extends RegexContentType> {
 describe('provideRegexTools', () => {
   const testCases: Array<[RegexContentType, Expectation<RegexContentType>]> = [
     [
+      'code',
+      {
+        shouldMatch: ['`code`'],
+        shouldNotMatch: ['random string', 'no ` close'],
+        expectedMatchFromFirstMatch: {
+          matched: '`code`',
+          content: { type: 'code', element: 'code' },
+        },
+      },
+    ],
+    [
       'image',
       {
         shouldMatch: [

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
@@ -14,7 +14,6 @@ export type RegexContentType = Exclude<
   | 'paragraph'
   | 'horizontal-rule'
   | 'code-block'
-  | 'code'
   | 'quote'
   | 'ordered-list'
 >;
@@ -34,6 +33,20 @@ export function provideRegexTools<T extends RegexContentType>(
 } {
   // keeping the switch statement in one place to make it easier to maintain.
   switch (value) {
+    case 'code':
+      return {
+        regex: /`(.+)`/,
+        contentFn: (regex) => {
+          const [matched, content] = regex;
+          return {
+            matched,
+            content: {
+              type: 'code',
+              element: content,
+            },
+          } as MatchedContent<T>;
+        },
+      };
     case 'image':
       return {
         regex: /!\[(.*?)]\((.*?)\)/,

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -295,4 +295,61 @@ describe('parseMarkdown', () => {
       ],
     );
   });
+
+  describe(`when reading inline-code.md`, () => {
+    itShouldBeParsed(
+      'inline-code.md',
+      [
+        'Inline code',
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                content: 'This is a paragraph with some ',
+              },
+              {
+                type: 'code',
+                element: 'inline code',
+              },
+              {
+                type: 'text',
+                content: ' in it.',
+              },
+            ],
+          },
+        ],
+      ],
+      [
+        'Inline code in link',
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'link',
+                content: [
+                  {
+                    type: 'text',
+                    content: 'This is a link with ',
+                  },
+                  {
+                    type: 'code',
+                    element: 'inline code',
+                  },
+                  {
+                    type: 'text',
+                    content: ' in it',
+                  },
+                ],
+                href: 'https://example.com',
+              },
+              { type: 'text', content: '.' },
+            ],
+          },
+        ],
+      ],
+    );
+  });
 });

--- a/ts-libs/md-parser/src/lib/reader-fns/read-paragraph.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-paragraph.ts
@@ -24,7 +24,7 @@ export function readParagraph(
   lines: string[],
   start: number,
 ): ReadResult<'paragraph'> {
-  const contentTypes: Array<AllowedRegexTypes> = ['image', 'link'];
+  const contentTypes: Array<AllowedRegexTypes> = ['code', 'image', 'link'];
   let line = lines[start];
 
   const contentMap: MatchedContentMap<AllowedRegexTypes> = {};

--- a/ts-libs/md-parser/src/lib/test-mds/inline-code.md
+++ b/ts-libs/md-parser/src/lib/test-mds/inline-code.md
@@ -1,0 +1,7 @@
+# Inline code
+
+This is a paragraph with some `inline code` in it.
+
+# Inline code in link
+
+[This is a link with `inline code` in it](https://example.com).


### PR DESCRIPTION
## Summary

Updated `md-parser` and `md-renderer` to handle `'code'` elements