### PR TITLE
Update markdown navigation for mobile

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/md-code.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code.component.ts
@@ -24,8 +24,6 @@ import { logUnexpectedContent } from '../fns';
       border: 1px solid;
       display: inline-flex;
       align-items: center;
-      position: relative;
-      top: -2px;
     }
 
     .md-code {

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.html
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.html
@@ -1,3 +1,11 @@
+<div class="mobile-navigation">
+  <pj-mdr-mobile-toc
+    [sections]="sections()"
+    [inViewSectionId]="intersectingSectionId()"
+    (sectionClick)="onNavigationClick($event)"
+  ></pj-mdr-mobile-toc>
+</div>
+
 <div class="markdown-document">
   <div class="markdown-navigation">
     @defer {

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.scss
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.scss
@@ -1,5 +1,15 @@
 $mobile: 768px;
 
+.mobile-navigation {
+  display: block;
+  position: fixed;
+  bottom: 0;
+  right: 0;
+
+  @media (min-width: $mobile) {
+    display: none;
+  }
+}
 .markdown-document {
   display: flex;
   flex-direction: column;
@@ -45,7 +55,7 @@ $mobile: 768px;
   }
 
   & .markdown-navigation {
-    // border: 1px solid pink;
+    display: none;
 
     @media (min-width: $mobile) {
       display: block;

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.spec.ts
@@ -1,9 +1,9 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MobileTocComponent, TableOfContentsComponent } from '../toc';
 
 import { CommonModule } from '@angular/common';
 import { MdRendererComponent } from './md-renderer.component';
-import { MockComponent } from 'ng-mocks';
-import { TableOfContentsComponent } from '../toc/table-of-contents.component';
+import { MockComponents } from 'ng-mocks';
 
 describe('MdRendererComponent', () => {
   let component: MdRendererComponent;
@@ -15,7 +15,9 @@ describe('MdRendererComponent', () => {
     })
       .overrideComponent(MdRendererComponent, {
         set: {
-          imports: [MockComponent(TableOfContentsComponent)],
+          imports: [
+            MockComponents(TableOfContentsComponent, MobileTocComponent),
+          ],
         },
       })
       .compileComponents();

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.ts
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.ts
@@ -15,16 +15,21 @@ import {
 import { CommonModule, isPlatformBrowser } from '@angular/common';
 import { MarkdownAst, MarkdownType } from '@peterjokumsen/ts-md-models';
 import { MdComponentMapService, MdContentService } from '../services';
+import { MobileTocComponent, TableOfContentsComponent } from '../toc';
 
 import { MdComponentsModule } from '../md-components.module';
 import { PjLogger } from '@peterjokumsen/ng-services';
-import { TableOfContentsComponent } from '../toc/table-of-contents.component';
 import { WithId } from '../models';
 
 @Component({
   selector: 'pj-mdr-md-renderer',
   standalone: true,
-  imports: [CommonModule, TableOfContentsComponent, MdComponentsModule],
+  imports: [
+    CommonModule,
+    TableOfContentsComponent,
+    MobileTocComponent,
+    MdComponentsModule,
+  ],
   providers: [MdContentService, MdComponentMapService],
   templateUrl: './md-renderer.component.html',
   styleUrl: './md-renderer.component.scss',

--- a/ng-libs/md-renderer/src/lib/toc/index.ts
+++ b/ng-libs/md-renderer/src/lib/toc/index.ts
@@ -1,0 +1,2 @@
+export * from './mobile-toc.component';
+export * from './table-of-contents.component';

--- a/ng-libs/md-renderer/src/lib/toc/mobile-toc.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/toc/mobile-toc.component.spec.ts
@@ -1,0 +1,53 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MatFabButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MobileTocComponent } from './mobile-toc.component';
+import { MockComponents } from 'ng-mocks';
+import { TableOfContentsComponent } from './table-of-contents.component';
+
+describe('MobileTocComponent', () => {
+  let component: MobileTocComponent;
+  let fixture: ComponentFixture<MobileTocComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [MobileTocComponent],
+    })
+      .overrideComponent(MobileTocComponent, {
+        set: {
+          imports: [
+            MockComponents(TableOfContentsComponent, MatFabButton, MatIcon),
+          ],
+        },
+      })
+      .compileComponents();
+
+    fixture = TestBed.createComponent(MobileTocComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('onSectionClicked', () => {
+    it('should set expanded to false', () => {
+      component.expanded.update(() => true);
+      const emitSpy = jest.spyOn(component.sectionClick, 'emit');
+      component.onSectionClicked('section-id');
+      expect(component.expanded()).toBe(false);
+      expect(emitSpy).toHaveBeenCalledWith('section-id');
+    });
+  });
+
+  describe('navToggle', () => {
+    it('should toggle expanded', () => {
+      component.navToggle();
+      expect(component.expanded()).toBe(true);
+      component.navToggle();
+      expect(component.expanded()).toBe(false);
+    });
+  });
+});

--- a/ng-libs/md-renderer/src/lib/toc/mobile-toc.component.ts
+++ b/ng-libs/md-renderer/src/lib/toc/mobile-toc.component.ts
@@ -1,0 +1,102 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  input,
+  output,
+  signal,
+} from '@angular/core';
+import {
+  animate,
+  keyframes,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+import { CommonModule } from '@angular/common';
+import { MarkdownSection } from '@peterjokumsen/ts-md-models';
+import { MatFabButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { TableOfContentsComponent } from './table-of-contents.component';
+import { WithId } from '../models';
+
+@Component({
+  selector: 'pj-mdr-mobile-toc',
+  standalone: true,
+  imports: [CommonModule, TableOfContentsComponent, MatFabButton, MatIcon],
+  animations: [
+    trigger('showHide', [
+      transition(':enter', [
+        animate(
+          '300ms ease-in',
+          keyframes([
+            style({ offset: 0, opacity: 0 }),
+            style({ offset: 1, opacity: 1 }),
+          ]),
+        ),
+      ]),
+      transition(':leave', [
+        animate(
+          '500ms ease-out',
+          keyframes([
+            style({ offset: 0, opacity: 1 }),
+            style({ offset: 1, opacity: 0 }),
+          ]),
+        ),
+      ]),
+    ]),
+  ],
+  template: `
+    @if (expanded()) {
+      <div @showHide class="toc">
+        <pj-mdr-table-of-contents
+          [sections]="sections()"
+          [inViewSectionId]="inViewSectionId()"
+          (sectionClick)="onSectionClicked($event)"
+        ></pj-mdr-table-of-contents>
+      </div>
+    }
+    <div class="nav-toggle">
+      <button
+        mat-fab
+        color="primary"
+        (click)="navToggle()"
+        [attr.aria-label]="'Expand table of contents'"
+      >
+        <mat-icon>menu</mat-icon>
+      </button>
+    </div>
+  `,
+  styles: `
+    .nav-toggle {
+      margin: 1rem;
+      float: right;
+    }
+
+    .toc {
+      max-height: calc(100vh - 6rem);
+      overflow-y: auto;
+      max-width: 400px;
+      border-radius: 10px;
+      padding: 1rem;
+      background-color: rgba(0, 0, 0, 0.5);
+      margin-top: 1rem;
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MobileTocComponent {
+  expanded = signal(false);
+  sections = input<WithId<MarkdownSection>[]>([]);
+  inViewSectionId = input<string>();
+  sectionClick = output<string>();
+
+  navToggle() {
+    this.expanded.update((v) => !v);
+  }
+
+  onSectionClicked(sectionId: string) {
+    this.expanded.update(() => false);
+    this.sectionClick.emit(sectionId);
+  }
+}

--- a/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.html
+++ b/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.html
@@ -1,5 +1,5 @@
 <div @list class="table-of-contents">
-  @if (inViewSectionId() !== '') {
+  @if (showBackToTop()) {
     <button
       mat-raised-button
       color="primary"

--- a/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.scss
+++ b/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.scss
@@ -3,3 +3,7 @@
   flex-direction: column;
   gap: 1rem;
 }
+
+button {
+  transition: background-color 0.3s;
+}

--- a/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.spec.ts
@@ -1,15 +1,28 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { PjBrowserTools } from '@peterjokumsen/ng-services';
 import { TableOfContentsComponent } from './table-of-contents.component';
 
 describe('TableOfContentsComponent', () => {
   let component: TableOfContentsComponent;
   let fixture: ComponentFixture<TableOfContentsComponent>;
+  let browserToolsSpy: Partial<jest.Mocked<PjBrowserTools>>;
+  let windowSpy: Partial<jest.Mocked<Window>>;
 
   beforeEach(async () => {
+    windowSpy = {
+      scrollY: 250,
+    };
+    browserToolsSpy = {
+      window: windowSpy as unknown as Window,
+    };
     await TestBed.configureTestingModule({
       imports: [TableOfContentsComponent, NoopAnimationsModule],
+      providers: [
+        // providers
+        { provide: PjBrowserTools, useValue: browserToolsSpy },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(TableOfContentsComponent);
@@ -19,5 +32,13 @@ describe('TableOfContentsComponent', () => {
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('onScroll', () => {
+    it('should update scroll height', () => {
+      component.inViewSectionId.apply(() => 'section');
+      component.onScroll();
+      expect(component.showBackToTop()).toBe(true);
+    });
   });
 });

--- a/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.ts
+++ b/ng-libs/md-renderer/src/lib/toc/table-of-contents.component.ts
@@ -1,9 +1,14 @@
 import {
   ChangeDetectionStrategy,
   Component,
+  HostListener,
+  computed,
+  inject,
   input,
   output,
+  signal,
 } from '@angular/core';
+import { PjBrowserTools, PjLogger } from '@peterjokumsen/ng-services';
 import {
   animate,
   animateChild,
@@ -63,7 +68,21 @@ import { WithId } from '../models';
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class TableOfContentsComponent {
+  private _logger = inject(PjLogger, { optional: true });
+  private _browserTools = inject(PjBrowserTools, { optional: true });
+  private _scrollPos = signal(this._browserTools?.window?.scrollY ?? 0);
+
+  showBackToTop = computed(() => {
+    const inView = this.inViewSectionId();
+    return this._scrollPos() > 200 && inView !== '';
+  });
   sections = input<WithId<MarkdownSection>[]>([]);
   inViewSectionId = input<string>();
   sectionClick = output<string>();
+
+  @HostListener('document:scroll') onScroll() {
+    const scrollPos = this._browserTools?.window?.scrollY;
+    if (!scrollPos) return;
+    this._scrollPos.update(() => scrollPos);
+  }
 }


### PR DESCRIPTION
## Summary

Created `MobileTocComponent`, rendered in `md-renderer` component, with position absolute to prevent element width from affecting width of content.

Fixes #100 