### PR TITLE
Update parser and renderer to handle code blocks

### DIFF
--- a/apps/blog/src/app/pages/about-me/about-me.component.ts
+++ b/apps/blog/src/app/pages/about-me/about-me.component.ts
@@ -60,6 +60,11 @@ The repository for this blog is available on GitHub.
 ![new image](/assets/images/basic-image.webp)
 
 You can find it at [peterjokumsen/peterjokumsen-nx-workspace](https://github.com/peterjokumsen/peterjokumsen-nx-workspace?tab=readme-ov-file#peterjokumsen-blog).
+
+\`\`\`shell
+# Clone the repository
+git clone https://github.com/peterjokumsen/peterjokumsen-nx-workspace.git
+\`\`\`
 `);
 
   ngOnInit(): void {

--- a/ng-libs/md-renderer/src/lib/components/index.ts
+++ b/ng-libs/md-renderer/src/lib/components/index.ts
@@ -1,4 +1,5 @@
 export * from './md-code.component';
+export * from './md-code-block.component';
 export * from './md-horizontal-rule.component';
 export * from './md-image.component';
 export * from './md-link.component';

--- a/ng-libs/md-renderer/src/lib/components/md-code-block.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code-block.component.spec.ts
@@ -1,0 +1,67 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogFns, PjLogger } from '@peterjokumsen/ng-services';
+
+import { MdCodeBlockComponent } from './md-code-block.component';
+import { logUnexpectedContent } from '../fns';
+
+jest.mock('../fns');
+
+describe('MdCodeBlockComponent', () => {
+  let component: MdCodeBlockComponent;
+  let fixture: ComponentFixture<MdCodeBlockComponent>;
+  let logSpy: Partial<jest.Mocked<LogFns>>;
+
+  beforeEach(async () => {
+    logSpy = {
+      warn: jest.fn().mockName('warn'),
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        // providers
+        { provide: PjLogger, useValue: { to: logSpy } },
+      ],
+      declarations: [MdCodeBlockComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MdCodeBlockComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('content', () => {
+    it('should extract lines', () => {
+      component.content = { type: 'code-block', lines: ['value1', 'value2'] };
+      expect(component.lines()).toEqual('value1\nvalue2');
+    });
+
+    it('should extract language', () => {
+      component.content = { type: 'code-block', language: 'value', lines: [] };
+      expect(component.language()).toEqual('value');
+    });
+
+    describe('when content is not a code-block element', () => {
+      it('should reset values', () => {
+        const logFnSpy = jest
+          .mocked(logUnexpectedContent)
+          .mockName('logUnexpectedContent');
+        component.lines.update(() => 'value');
+        component.language.update(() => 'lang');
+
+        component.content = 'value';
+
+        expect(logFnSpy).toHaveBeenCalledWith(
+          'MdCodeBlockComponent',
+          'value',
+          logSpy,
+        );
+        expect(component.lines()).toEqual(null);
+        expect(component.language()).toEqual('');
+      });
+    });
+  });
+});

--- a/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
@@ -1,0 +1,49 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+
+import { HasContent } from '../has-content';
+import { PjLogger } from '@peterjokumsen/ng-services';
+import { logUnexpectedContent } from '../fns';
+import { mdModelCheck } from '@peterjokumsen/ts-md-models';
+
+@Component({
+  selector: 'pj-mdr-md-code-block',
+  template: `
+    @if (lines()) {
+      <pre><code class="{{ language() }}">{{ lines() }}</code></pre>
+    }
+  `,
+  styles: `
+    :host {
+      display: block;
+      padding: 1rem;
+      border-radius: 5px;
+      border: 1px solid var(--primary-color);
+    }
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MdCodeBlockComponent implements HasContent<'code-block'> {
+  private _logger = inject(PjLogger, { optional: true });
+
+  language = signal<string>('');
+  lines = signal<string | null>(null);
+
+  set content(value: HasContent<'code-block'>['content']) {
+    let nextLines: string | null = null;
+    let language = '';
+    if (typeof value === 'string' || !mdModelCheck('code-block', value)) {
+      logUnexpectedContent('MdCodeBlockComponent', value, this._logger?.to);
+    } else {
+      nextLines = value.lines.join('\n');
+      language = value.language as string;
+    }
+
+    this.language.update(() => language);
+    this.lines.update(() => nextLines);
+  }
+}

--- a/ng-libs/md-renderer/src/lib/components/md-code.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code.component.ts
@@ -13,21 +13,14 @@ import { logUnexpectedContent } from '../fns';
   selector: 'pj-mdr-md-code',
   template: `
     @if (elementValue()) {
-      <span class="md-code">{{ elementValue() }}</span>
+      <code class="primary-colors">{{ elementValue() }}</code>
     }
   `,
   styles: `
-    :host {
-      padding: 2px 5px;
-      border-radius: 5px;
-      font-family: monospace, monospace;
-      border: 1px solid;
-      display: inline-flex;
-      align-items: center;
-    }
-
-    .md-code {
-      font-size: 0.9rem;
+    code {
+      display: inline-block;
+      padding: 1px 4px;
+      border-radius: 4px;
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/ng-libs/md-renderer/src/lib/filter-content-types.ts
+++ b/ng-libs/md-renderer/src/lib/filter-content-types.ts
@@ -2,17 +2,19 @@ import { MarkdownContentType, MarkdownType } from '@peterjokumsen/ts-md-models';
 
 export type ExpectedContentTypes = Extract<
   MarkdownContentType,
-  | 'section'
-  | 'paragraph'
-  | 'link'
-  | 'text'
-  | 'image'
-  | 'list'
   | 'code'
+  | 'code-block'
   | 'horizontal-rule'
+  | 'image'
+  | 'link'
+  | 'list'
+  | 'paragraph'
+  | 'section'
+  | 'text'
 >;
 
 const allowed: Required<Record<ExpectedContentTypes, object>> = {
+  'code-block': {},
   'horizontal-rule': {},
   code: {},
   image: {},

--- a/ng-libs/md-renderer/src/lib/md-components.module.ts
+++ b/ng-libs/md-renderer/src/lib/md-components.module.ts
@@ -1,5 +1,6 @@
 import { MD_COMPONENT_TYPE_MAP, MdComponentTypeMap } from './injection.tokens';
 import {
+  MdCodeBlockComponent,
   MdCodeComponent,
   MdHorizontalRuleComponent,
   MdImageComponent,
@@ -24,6 +25,7 @@ import { MdContentInjectionDirective } from './directives/md-content-injection.d
     MdContentInjectionDirective,
 
     MdCodeComponent,
+    MdCodeBlockComponent,
     MdHorizontalRuleComponent,
     MdImageComponent,
     MdLinkComponent,

--- a/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
+++ b/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
@@ -2,6 +2,7 @@ import { HasContent, HasContentBase } from '../has-content';
 import { Injectable, Type, inject } from '@angular/core';
 import { MD_COMPONENT_TYPE_MAP, MdComponentTypeMap } from '../injection.tokens';
 import {
+  MdCodeBlockComponent,
   MdCodeComponent,
   MdHorizontalRuleComponent,
   MdImageComponent,
@@ -19,6 +20,7 @@ import { ExpectedContentTypes } from '../filter-content-types';
 export class MdComponentMapService {
   private _typeMap = inject(MD_COMPONENT_TYPE_MAP, { optional: true });
   private _defaultMap: MdComponentTypeMap = {
+    'code-block': MdCodeBlockComponent,
     'horizontal-rule': MdHorizontalRuleComponent,
     code: MdCodeComponent,
     image: MdImageComponent,

--- a/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.spec.ts
@@ -23,6 +23,13 @@ describe('getSectionContentType', () => {
       },
     ],
     [
+      'line has "  ```"',
+      {
+        line: '  ```',
+        expectedType: 'code-block',
+      },
+    ],
+    [
       'line has "---"',
       {
         line: '---',

--- a/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
@@ -8,7 +8,10 @@ import { SectionContentType } from '@peterjokumsen/ts-md-models';
  */
 export function getSectionContentType(
   line: string,
-): Extract<SectionContentType, 'section' | 'list' | 'paragraph'> {
+): Extract<
+  SectionContentType,
+  'section' | 'code-block' | 'list' | 'paragraph'
+> {
   const trimmedLine = line.trimStart();
   if (trimmedLine.startsWith('#')) {
     return 'section';
@@ -16,6 +19,10 @@ export function getSectionContentType(
 
   if (trimmedLine.startsWith('- ')) {
     return 'list';
+  }
+
+  if (trimmedLine.startsWith('```')) {
+    return 'code-block';
   }
 
   return 'paragraph';

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -520,4 +520,68 @@ describe('parseMarkdown', () => {
       ],
     ]);
   });
+
+  describe('when reading code-block.md', () => {
+    itShouldBeParsed(
+      'code-block.md',
+      [
+        'CSharp',
+        [
+          {
+            type: 'code-block',
+            language: 'csharp',
+            indent: 0,
+            lines: [
+              'public class Program',
+              '{',
+              '    public static void Main()',
+              '    {',
+              '        Console.WriteLine("Hello, World!");',
+              '    }',
+              '}',
+            ],
+          },
+        ],
+      ],
+      [
+        'TypeScript',
+        [
+          {
+            type: 'code-block',
+            language: 'typescript',
+            indent: 0,
+            lines: [
+              'class Program {',
+              '  static Main() {',
+              "    console.log('Hello, World!');",
+              '  }',
+              '}',
+            ],
+          },
+        ],
+      ],
+      [
+        'Shell',
+        [
+          {
+            type: 'code-block',
+            language: 'shell',
+            indent: 0,
+            lines: ['git log --oneline --first-parent'],
+          },
+        ],
+      ],
+      [
+        'No lang',
+        [
+          {
+            type: 'code-block',
+            language: '',
+            indent: 0,
+            lines: ['echo "Hello, World!"'],
+          },
+        ],
+      ],
+    );
+  });
 });

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -54,13 +54,13 @@ describe('parseMarkdown', () => {
       );
 
       if (!markdown) {
-        fail(`Could not read file ${fileName} for test`);
+        throw new Error(`Could not read file '${fileName}' for test`);
       }
 
       const result = parseMarkdown(markdown);
       sections = result.sections;
       if (sections.length !== expectations.length) {
-        fail(
+        throw new Error(
           `Expected ${expectations.length} sections, but got ${sections.length}`,
         );
       }

--- a/ts-libs/md-parser/src/lib/reader-fns/generate-markdown-sections.spec.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/generate-markdown-sections.spec.ts
@@ -46,7 +46,7 @@ describe('readMarkdownSection', () => {
       }
 
       if (!generator.next().done) {
-        fail('Generator did not finish');
+        throw new Error('Generator did not finish');
       }
     });
 
@@ -124,7 +124,7 @@ describe('readMarkdownSection', () => {
         content: [{ type: 'text', content: 'Some content' }],
       });
       if (!generator.next().done) {
-        fail('Generator did not finish');
+        throw new Error('Generator did not finish');
       }
     });
   });

--- a/ts-libs/md-parser/src/lib/reader-fns/read-code-block.spec.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-code-block.spec.ts
@@ -1,0 +1,35 @@
+import { readCodeBlock } from './read-code-block';
+
+describe('readCodeBlock', () => {
+  it('should read a code block', () => {
+    // Arrange
+    const lines = ['```typescript', 'const a = 1;', '```'];
+    const start = 0;
+    // Act
+    const result = readCodeBlock(lines, start);
+    // Assert
+    expect(result).toEqual({
+      lastLineIndex: 2,
+      result: {
+        type: 'code-block',
+        indent: 0,
+        language: 'typescript',
+        lines: ['const a = 1;'],
+      },
+    });
+  });
+
+  describe('when first line is not code block', () => {
+    it('should throw an error', () => {
+      // Arrange
+      const lines = ['const a = 1;', '```typescript', 'const b = 2;', '```'];
+      const start = 0;
+      // Act
+      const act = () => readCodeBlock(lines, start);
+      // Assert
+      expect(act).toThrow(
+        `Invalid code block start. "const a = 1;" does not start with "\`\`\`".`,
+      );
+    });
+  });
+});

--- a/ts-libs/md-parser/src/lib/reader-fns/read-code-block.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-code-block.ts
@@ -1,0 +1,33 @@
+import { ReadResult } from '../_models';
+
+export function readCodeBlock(
+  lines: string[],
+  start: number,
+): ReadResult<'code-block'> {
+  const line = lines[start];
+  if (!line.trimStart().startsWith('```')) {
+    throw new Error(
+      `Invalid code block start. "${line}" does not start with "\`\`\`".`,
+    );
+  }
+
+  const language = line.trimStart().slice(3).trim();
+  const indent = line.indexOf('```');
+  const codeBlockLines: string[] = [];
+  let lineIndex = start + 1;
+  for (; lineIndex < lines.length; lineIndex++) {
+    const codeLine = lines[lineIndex];
+    if (codeLine.trimStart().startsWith('```')) break;
+    codeBlockLines.push(codeLine.slice(indent));
+  }
+
+  return {
+    result: {
+      type: 'code-block',
+      indent,
+      language,
+      lines: codeBlockLines,
+    },
+    lastLineIndex: lineIndex,
+  };
+}

--- a/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
@@ -5,6 +5,7 @@ import {
 import { getHeaderLevel, getSectionContentType } from '../helper-fns';
 
 import { ReadResult } from '../_models';
+import { readCodeBlock } from './read-code-block';
 import { readList } from './read-list';
 import { readParagraph } from './read-paragraph';
 
@@ -60,6 +61,12 @@ export function readSection(
       }
       case 'paragraph': {
         const { result, lastLineIndex } = readParagraph(lines, i);
+        section.contents.push(result);
+        i = lastLineIndex;
+        break;
+      }
+      case 'code-block': {
+        const { result, lastLineIndex } = readCodeBlock(lines, i);
         section.contents.push(result);
         i = lastLineIndex;
         break;

--- a/ts-libs/md-parser/src/lib/test-mds/code-block.md
+++ b/ts-libs/md-parser/src/lib/test-mds/code-block.md
@@ -1,0 +1,33 @@
+# CSharp
+
+```csharp
+public class Program
+{
+    public static void Main()
+    {
+        Console.WriteLine("Hello, World!");
+    }
+}
+```
+
+# TypeScript
+
+```typescript
+class Program {
+  static Main() {
+    console.log('Hello, World!');
+  }
+}
+```
+
+# Shell
+
+```shell
+git log --oneline --first-parent
+```
+
+# No lang
+
+```
+echo "Hello, World!"
+```

--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -15,6 +15,7 @@ export interface MarkdownCode extends HasMarkdownContentType {
 export interface MarkdownCodeBlock extends HasMarkdownContentType {
   type: 'code-block';
   language?: unknown; // TODO: Add language type(s)
+  indent?: number;
   lines: string[];
 }
 


### PR DESCRIPTION
## Summary

- Updated `md-parser` to read code blocks from markdown.
- Updated `md-renderer` to display parsed code blocks.
- Fixed `md-renderer` display of code elements.

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Screenshots

<!-- If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily. -->

## Related issues

Closes #45

## Testing instructions

<!-- Instructions on how to test the changes made in the pull
request, helping reviewers validate the code. -->

</details>
<!-- End of Optional Sections -->
