### PR TITLE
fix(.github): include `id-token` permission for post_deploy

### DIFF
--- a/.github/workflows/_workflow.jobs.post_deploy.yml
+++ b/.github/workflows/_workflow.jobs.post_deploy.yml
@@ -15,6 +15,7 @@ on:
 permissions:
   contents: read
   pull-requests: write
+  id-token: write
 
 jobs:
   # wait for the deployment to return a successful response


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Added `id-token: write` permission for post_deploy workflow, to allow for authenticating with Azure.
