### PR TITLE
fix(md-renderer): improve display for mobile devices

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
@@ -23,6 +23,7 @@ import { mdModelCheck } from '@peterjokumsen/ts-md-models';
       padding: 1rem;
       border-radius: 5px;
       border: 1px solid var(--primary-color);
+      overflow-x: scroll;
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.html
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.html
@@ -1,9 +1,13 @@
 <div class="mobile-navigation">
-  <pj-mdr-mobile-toc
-    [sections]="sections()"
-    [inViewSectionId]="intersectingSectionId()"
-    (sectionClick)="onNavigationClick($event)"
-  ></pj-mdr-mobile-toc>
+  @defer {
+    <pj-mdr-mobile-toc
+      [sections]="sections()"
+      [inViewSectionId]="intersectingSectionId()"
+      (sectionClick)="onNavigationClick($event)"
+    ></pj-mdr-mobile-toc>
+  } @placeholder {
+    <div class="navigation-placeholder"></div>
+  }
 </div>
 
 <div class="markdown-document">

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.scss
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.scss
@@ -37,6 +37,7 @@ $mobile: 768px;
 .markdown-contents {
   flex: 1;
   margin: 0 auto;
+  width: 100%;
 
   .section-container {
     display: flex;


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Set container for markdown content to 100%, use overflow-x for code-block content to prevent scroll.