### PR TITLE
fix(.github): set `id-token` in correct workflow

### DIFF
--- a/.github/workflows/_workflow.jobs.clean_pull_request.yml
+++ b/.github/workflows/_workflow.jobs.clean_pull_request.yml
@@ -22,6 +22,7 @@ on:
 
 permissions:
   contents: read
+  id-token: write
 
 jobs:
   # Close the deployed static web app

--- a/.github/workflows/_workflow.jobs.post_deploy.yml
+++ b/.github/workflows/_workflow.jobs.post_deploy.yml
@@ -15,7 +15,6 @@ on:
 permissions:
   contents: read
   pull-requests: write
-  id-token: write
 
 jobs:
   # wait for the deployment to return a successful response


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Set `id-token: write` in clean up re-usable workflow. Incorrectly set in post deploy workflow before this.