### PR TITLE
feat(md-parser): parse comment blocks

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:uncommitted": "nx affected --target=test --uncommitted",
     "format": "nx format:write",
     "format:check": "nx format:check",
-    "pre-commit:write": "nx format:write & npm run lint:uncommitted",
+    "pre-commit:write": "nx format:write && npm run lint:uncommitted",
     "pre-push:check": "nx affected --base=origin/main -t lint test build --parallel=5",
     "prepare": "husky",
     "mega-lint": "npx mega-linter-runner --flavor javascript"

--- a/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
@@ -2,7 +2,7 @@ import { SectionContentType } from '@peterjokumsen/ts-md-models';
 
 /**
  * Gets the content type of the provided line.
- * Can be either a `'section'`, `'list'` or `'paragraph'`.
+ * Can be either a `'section'`, `'list'`, `'commented'`, or `'paragraph'`.
  * @param line The line to check.
  * @returns The content type of the line.
  */
@@ -10,7 +10,7 @@ export function getSectionContentType(
   line: string,
 ): Extract<
   SectionContentType,
-  'section' | 'code-block' | 'list' | 'paragraph'
+  'section' | 'code-block' | 'list' | 'paragraph' | 'commented'
 > {
   const trimmedLine = line.trimStart();
   if (trimmedLine.startsWith('#')) {
@@ -23,6 +23,10 @@ export function getSectionContentType(
 
   if (trimmedLine.startsWith('```')) {
     return 'code-block';
+  }
+
+  if (trimmedLine.startsWith('<!--')) {
+    return 'commented';
   }
 
   return 'paragraph';

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
@@ -73,6 +73,20 @@ describe('provideRegexTools', () => {
         },
       },
     ],
+    [
+      'commented',
+      {
+        shouldMatch: ['<!-- something', '<!-- something -->'],
+        shouldNotMatch: ['regular line'],
+        expectedMatchFromFirstMatch: {
+          matched: '<!-- something',
+          content: {
+            type: 'commented',
+            lines: ['something'],
+          },
+        },
+      },
+    ],
   ];
 
   describe.each(testCases)(

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
@@ -76,10 +76,10 @@ describe('provideRegexTools', () => {
     [
       'commented',
       {
-        shouldMatch: ['<!-- something', '<!-- something -->'],
+        shouldMatch: ['<!-- something -->'],
         shouldNotMatch: ['regular line'],
         expectedMatchFromFirstMatch: {
-          matched: '<!-- something',
+          matched: '<!-- something -->',
           content: {
             type: 'commented',
             lines: ['something'],

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
@@ -107,6 +107,20 @@ export function provideRegexTools<T extends RegexContentType>(
           } as MatchedContent<T>;
         },
       };
+    case 'commented':
+      return {
+        regex: /<!--(.*)(-->)?/,
+        contentFn: (regex) => {
+          const [matched, comment] = regex;
+          return {
+            matched,
+            content: {
+              type: 'commented',
+              lines: comment.trim().split('\n'),
+            },
+          } as MatchedContent<T>;
+        },
+      };
     default: {
       // force compilation to fail if a case is missing
       const _: never = value;

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
@@ -109,7 +109,7 @@ export function provideRegexTools<T extends RegexContentType>(
       };
     case 'commented':
       return {
-        regex: /<!--(.*)(-->)?/,
+        regex: /<!--(.*)-->/,
         contentFn: (regex) => {
           const [matched, comment] = regex;
           return {

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -584,4 +584,25 @@ describe('parseMarkdown', () => {
       ],
     );
   });
+
+  describe('when reading commented.md', () => {
+    itShouldBeParsed('commented.md', [
+      'Comment',
+      [
+        {
+          type: 'commented',
+          lines: ['Hello world!', 'More comment.'],
+        },
+        {
+          type: 'paragraph',
+          content: [
+            {
+              type: 'text',
+              content: 'Comment.',
+            },
+          ],
+        },
+      ],
+    ]);
+  });
 });

--- a/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.spec.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.spec.ts
@@ -1,0 +1,13 @@
+import { readCommentedBlock } from './read-commented-block';
+
+describe('readCommentedBlock', () => {
+  it('should read commented block', () => {
+    const lines = ['asdf', '<!-- starting', 'ending --> other stuffs.', 'more'];
+
+    const result = readCommentedBlock(lines, 1);
+
+    expect(result.lastLineIndex).toEqual(2);
+    expect(result.result.lines).toEqual(['starting', 'ending']);
+    expect(lines).toEqual(['asdf', '<!-- starting', 'other stuffs.', 'more']);
+  });
+});

--- a/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.spec.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.spec.ts
@@ -8,6 +8,26 @@ describe('readCommentedBlock', () => {
 
     expect(result.lastLineIndex).toEqual(2);
     expect(result.result.lines).toEqual(['starting', 'ending']);
-    expect(lines).toEqual(['asdf', '<!-- starting', 'other stuffs.', 'more']);
+    expect(lines).toEqual(['asdf', '', 'other stuffs.', 'more']);
+  });
+
+  it('should set line to index before to re-read current line', () => {
+    const lines = ['a', 'b <!--', 'comment', '-->', 'c'];
+
+    const result = readCommentedBlock(lines, 1);
+
+    expect(result.result.lines).toEqual(['comment']);
+    expect(result.lastLineIndex).toEqual(0);
+    expect(lines).toEqual(['a', 'b ', '', '', 'c']);
+  });
+
+  it('should handle in-line comment', () => {
+    const lines = ['a', 'b <!-- comment --> c', 'd'];
+
+    const result = readCommentedBlock(lines, 1);
+
+    expect(result.result.lines).toEqual(['comment']);
+    expect(result.lastLineIndex).toEqual(0);
+    expect(lines).toEqual(['a', 'b  c', 'd']);
   });
 });

--- a/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-commented-block.ts
@@ -1,0 +1,39 @@
+import { MarkdownCommentBlock } from '@peterjokumsen/ts-md-models';
+import { ReadResult } from '../_models';
+
+export function readCommentedBlock(
+  inputLines: string[],
+  i: number,
+): ReadResult<'commented'> {
+  const lines = [];
+  for (; i < inputLines.length; i++) {
+    const currentLine = inputLines[i];
+    if (currentLine.includes('<!--')) {
+      const split = currentLine.split('<!--');
+      if (split[1]?.trim()) {
+        lines.push(split[1].trim());
+      }
+
+      continue;
+    }
+    if (currentLine.includes('-->')) {
+      const split = currentLine.split('-->');
+      if (split[0]?.trim()) {
+        lines.push(split[0].trim());
+      }
+      inputLines[i] = split[1]?.trim() ?? '';
+      break;
+    }
+
+    lines.push(currentLine);
+  }
+
+  const result: MarkdownCommentBlock = {
+    type: 'commented',
+    lines,
+  };
+  return {
+    result,
+    lastLineIndex: i,
+  };
+}

--- a/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
@@ -6,6 +6,7 @@ import { getHeaderLevel, getSectionContentType } from '../helper-fns';
 
 import { ReadResult } from '../_models';
 import { readCodeBlock } from './read-code-block';
+import { readCommentedBlock } from './read-commented-block';
 import { readList } from './read-list';
 import { readParagraph } from './read-paragraph';
 
@@ -35,6 +36,7 @@ export function readSection(
   };
 
   let i = start + 1;
+
   for (; i < lines.length; i++) {
     const line = lines[i];
     if (line.trim() === '') {
@@ -67,6 +69,12 @@ export function readSection(
       }
       case 'code-block': {
         const { result, lastLineIndex } = readCodeBlock(lines, i);
+        section.contents.push(result);
+        i = lastLineIndex;
+        break;
+      }
+      case 'commented': {
+        const { result, lastLineIndex } = readCommentedBlock(lines, i);
         section.contents.push(result);
         i = lastLineIndex;
         break;

--- a/ts-libs/md-parser/test-mds/commented.md
+++ b/ts-libs/md-parser/test-mds/commented.md
@@ -1,0 +1,8 @@
+# Comment
+
+<!--
+Hello world!
+More comment.
+-->
+
+Comment.

--- a/ts-libs/ts-md-models/src/lib/markdown-content-type.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content-type.ts
@@ -9,4 +9,5 @@ export type MarkdownContentType =
   | 'image'
   | 'link'
   | 'paragraph'
-  | 'text';
+  | 'text'
+  | 'commented';

--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -19,6 +19,11 @@ export interface MarkdownCodeBlock extends HasMarkdownContentType {
   lines: string[];
 }
 
+export interface MarkdownCommentBlock extends HasMarkdownContentType {
+  type: 'commented';
+  lines: string[];
+}
+
 export interface MarkdownListElement extends HasMarkdownContentType {
   type: 'list' | 'ordered-list';
   indent: number;
@@ -75,6 +80,7 @@ export interface MarkdownSection extends HasMarkdownContentType {
 export type MarkdownContent =
   | MarkdownCode
   | MarkdownCodeBlock
+  | MarkdownCommentBlock
   | MarkdownList
   | MarkdownOrderedList
   | MarkdownQuote

--- a/ts-libs/ts-md-models/src/lib/md-model-check.spec.ts
+++ b/ts-libs/ts-md-models/src/lib/md-model-check.spec.ts
@@ -27,6 +27,7 @@ describe('mdModelCheck', () => {
     quote: { type: 'quote', content: 'quote-content' },
     section: { type: 'section', title: 'section-title', contents: [] },
     text: { type: 'text', content: 'text-content' },
+    commented: { type: 'commented', lines: [] },
   };
 
   it('should help narrow down the type of MarkdownContent', () => {

--- a/ts-libs/ts-md-models/src/lib/section-content-type.ts
+++ b/ts-libs/ts-md-models/src/lib/section-content-type.ts
@@ -3,6 +3,7 @@ import { MarkdownContentType } from './markdown-content-type';
 export type SectionContentType = Extract<
   MarkdownContentType,
   | 'code-block'
+  | 'commented'
   | 'horizontal-rule'
   | 'list'
   | 'ordered-list'


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Parse comment blocks to an element with type `commented`
