### PR TITLE
feat(md-renderer): handle `commented` markdown element

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/index.ts
+++ b/ng-libs/md-renderer/src/lib/components/index.ts
@@ -1,5 +1,6 @@
 export * from './md-code.component';
 export * from './md-code-block.component';
+export * from './md-commented.component';
 export * from './md-horizontal-rule.component';
 export * from './md-image.component';
 export * from './md-link.component';

--- a/ng-libs/md-renderer/src/lib/components/md-commented.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-commented.component.spec.ts
@@ -1,0 +1,60 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { LogFns, PjLogger } from '@peterjokumsen/ng-services';
+
+import { MdCommentedComponent } from './md-commented.component';
+import { logUnexpectedContent } from '../fns';
+
+jest.mock('../fns');
+
+describe('MdCommentedComponent', () => {
+  let component: MdCommentedComponent;
+  let fixture: ComponentFixture<MdCommentedComponent>;
+  let logSpy: Partial<jest.Mocked<LogFns>>;
+
+  beforeEach(async () => {
+    logSpy = {
+      warn: jest.fn().mockName('warn'),
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        // providers
+        { provide: PjLogger, useValue: { to: logSpy } },
+      ],
+      declarations: [MdCommentedComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(MdCommentedComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  describe('content', () => {
+    it('should extract element value', () => {
+      component.content = { type: 'commented', lines: ['value'] };
+      expect(component.commentLines()).toEqual(['value']);
+    });
+
+    describe('when content is not a commented element', () => {
+      it('should reset element value', () => {
+        const logFnSpy = jest
+          .mocked(logUnexpectedContent)
+          .mockName('logUnexpectedContent');
+        component.commentLines.update(() => ['value']);
+
+        component.content = 'value';
+
+        expect(logFnSpy).toHaveBeenCalledWith(
+          'MdCodeComponent',
+          'value',
+          logSpy,
+        );
+        expect(component.commentLines()).toEqual([]);
+      });
+    });
+  });
+});

--- a/ng-libs/md-renderer/src/lib/components/md-commented.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-commented.component.ts
@@ -1,0 +1,35 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  inject,
+  signal,
+} from '@angular/core';
+
+import { HasContent } from '../has-content';
+import { PjLogger } from '@peterjokumsen/ng-services';
+import { logUnexpectedContent } from '../fns';
+
+@Component({
+  selector: 'pj-mdr-md-commented',
+  template: `
+    <!-- could possibly display comments here, for now ignoring it -->
+  `,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class MdCommentedComponent implements HasContent<'commented'> {
+  private _logger = inject(PjLogger, { optional: true });
+
+  commentLines = signal<string[]>([]);
+
+  set content(value: HasContent<'commented'>['content']) {
+    if (typeof value === 'string' || value.type !== 'commented') {
+      logUnexpectedContent('MdCodeComponent', value, this._logger?.to);
+
+      this.commentLines.update(() => []);
+      return;
+    }
+
+    this.commentLines.update(() => value.lines);
+  }
+}

--- a/ng-libs/md-renderer/src/lib/directives/md-content-injection.directive.ts
+++ b/ng-libs/md-renderer/src/lib/directives/md-content-injection.directive.ts
@@ -24,8 +24,6 @@ export class MdContentInjectionDirective {
   @Input('pjMdrMdContentInjection') set contentToRender(
     value: WithId<MarkdownType<ExpectedContentTypes>>,
   ) {
-    this._logger?.to.log('MdContentInjection initialized, %o', value);
-
     for (const child of this.getChildContents(value)) {
       const component = this.componentMap.getComponent(child.type);
       const instance =

--- a/ng-libs/md-renderer/src/lib/filter-content-types.ts
+++ b/ng-libs/md-renderer/src/lib/filter-content-types.ts
@@ -4,6 +4,7 @@ export type ExpectedContentTypes = Extract<
   MarkdownContentType,
   | 'code'
   | 'code-block'
+  | 'commented'
   | 'horizontal-rule'
   | 'image'
   | 'link'
@@ -17,6 +18,7 @@ const allowed: Required<Record<ExpectedContentTypes, object>> = {
   'code-block': {},
   'horizontal-rule': {},
   code: {},
+  commented: {},
   image: {},
   link: {},
   list: {},

--- a/ng-libs/md-renderer/src/lib/md-components.module.ts
+++ b/ng-libs/md-renderer/src/lib/md-components.module.ts
@@ -2,6 +2,7 @@ import { MD_COMPONENT_TYPE_MAP, MdComponentTypeMap } from './injection.tokens';
 import {
   MdCodeBlockComponent,
   MdCodeComponent,
+  MdCommentedComponent,
   MdHorizontalRuleComponent,
   MdImageComponent,
   MdLinkComponent,
@@ -26,6 +27,7 @@ import { MdContentInjectionDirective } from './directives/md-content-injection.d
 
     MdCodeComponent,
     MdCodeBlockComponent,
+    MdCommentedComponent,
     MdHorizontalRuleComponent,
     MdImageComponent,
     MdLinkComponent,

--- a/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.ts
+++ b/ng-libs/md-renderer/src/lib/md-renderer/md-renderer.component.ts
@@ -65,7 +65,6 @@ export class MdRendererComponent implements AfterViewInit, OnDestroy {
         const intersecting = entries.find((e) => e.isIntersecting);
         const id = intersecting?.target.id ?? '';
         if (id) {
-          this._logger?.to.log('Intersecting section:', id, entries);
           this.intersectingSectionId.update(() => id);
         }
       },

--- a/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
+++ b/ng-libs/md-renderer/src/lib/services/md-component-map.service.ts
@@ -4,6 +4,7 @@ import { MD_COMPONENT_TYPE_MAP, MdComponentTypeMap } from '../injection.tokens';
 import {
   MdCodeBlockComponent,
   MdCodeComponent,
+  MdCommentedComponent,
   MdHorizontalRuleComponent,
   MdImageComponent,
   MdLinkComponent,
@@ -23,6 +24,7 @@ export class MdComponentMapService {
     'code-block': MdCodeBlockComponent,
     'horizontal-rule': MdHorizontalRuleComponent,
     code: MdCodeComponent,
+    commented: MdCommentedComponent,
     image: MdImageComponent,
     link: MdLinkComponent,
     list: MdListComponent,


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Update renderer to ignore markdown elements with type of `commented`.