### PR TITLE
fix(md-renderer): update overflow for code-block

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-code-block.component.ts
@@ -22,8 +22,8 @@ import { mdModelCheck } from '@peterjokumsen/ts-md-models';
       display: block;
       padding: 1rem;
       border-radius: 5px;
-      border: 1px solid var(--primary-color);
-      overflow-x: scroll;
+      border: 1px solid;
+      overflow-x: auto;
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
## Summary

Updated style for `code-block` component, to use `auto` for overflow. To use scroll when content greater than current width, otherwise no scrollbar.

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Related issues

Fixes #120

</details>
<!-- End of Optional Sections -->
