### PR TITLE
feat(ts-md-models): reword properties for `quote` model

### DIFF
--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -46,7 +46,8 @@ export interface MarkdownParagraph extends HasMarkdownContentType {
 
 export interface MarkdownQuote extends HasMarkdownContentType {
   type: 'quote';
-  content: string | MarkdownType<SectionContentType>[];
+  indent?: number;
+  paragraphs: MarkdownParagraph[];
 }
 
 export interface MarkdownHorizontalRule extends HasMarkdownContentType {

--- a/ts-libs/ts-md-models/src/lib/md-model-check.spec.ts
+++ b/ts-libs/ts-md-models/src/lib/md-model-check.spec.ts
@@ -24,7 +24,7 @@ describe('mdModelCheck', () => {
       items: [{ type: 'paragraph', content: '' }],
     },
     paragraph: { type: 'paragraph', content: 'paragraph-content' },
-    quote: { type: 'quote', content: 'quote-content' },
+    quote: { type: 'quote', paragraphs: [] },
     section: { type: 'section', title: 'section-title', contents: [] },
     text: { type: 'text', content: 'text-content' },
     commented: { type: 'commented', lines: [] },


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Changes Made

- Renamed `content` to `paragraphs`
- Added an option `indent` property... against my better judgement but keeping with the `indent` added to other models
  > Because quotes can be indented, although I am not prepared to implement that as yet... will add an issue to hopefully get around to it.

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Related issues

Working on #49

</details>
<!-- End of Optional Sections -->
