### PR TITLE
fix(ts-md-models): extend `quote` `paragraphs` property

### DIFF
--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -47,7 +47,7 @@ export interface MarkdownParagraph extends HasMarkdownContentType {
 export interface MarkdownQuote extends HasMarkdownContentType {
   type: 'quote';
   indent?: number;
-  paragraphs: MarkdownParagraph[];
+  paragraphs: MarkdownType<'paragraph' | 'horizontal-rule'>[];
 }
 
 export interface MarkdownHorizontalRule extends HasMarkdownContentType {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Changes Made

- Enabled to allow `horizontal-rule` type

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Related issues

Worked on #49

</details>
<!-- End of Optional Sections -->
