### PR TITLE
feat(md-renderer): read `quote` elements from markdown

### DIFF
--- a/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.spec.ts
@@ -43,6 +43,13 @@ describe('getSectionContentType', () => {
         expectedType: 'paragraph',
       },
     ],
+    [
+      'line starts with >',
+      {
+        line: '  > Hello world',
+        expectedType: 'quote',
+      },
+    ],
   ])('when %s', (_, { line, expectedType }) => {
     it(`should return "${expectedType}"`, () => {
       expect(getSectionContentType(line)).toBe(expectedType);

--- a/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/get-section-content-type.ts
@@ -10,7 +10,7 @@ export function getSectionContentType(
   line: string,
 ): Extract<
   SectionContentType,
-  'section' | 'code-block' | 'list' | 'paragraph' | 'commented'
+  'section' | 'code-block' | 'list' | 'paragraph' | 'commented' | 'quote'
 > {
   const trimmedLine = line.trimStart();
   if (trimmedLine.startsWith('#')) {
@@ -27,6 +27,10 @@ export function getSectionContentType(
 
   if (trimmedLine.startsWith('<!--')) {
     return 'commented';
+  }
+
+  if (trimmedLine.startsWith('> ')) {
+    return 'quote';
   }
 
   return 'paragraph';

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -605,4 +605,63 @@ describe('parseMarkdown', () => {
       ],
     ]);
   });
+
+  xdescribe('when reading quote.md', () => {
+    itShouldBeParsed(
+      'quote.md',
+      [
+        'Quote example',
+        [
+          {
+            type: 'quote',
+            indent: 0,
+            paragraphs: [
+              {
+                type: 'paragraph',
+                content: [
+                  {
+                    type: 'text',
+                    content: 'This is a quote',
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      ],
+      [
+        'Multi-line quote',
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                content: 'First line',
+              },
+              {
+                type: 'text',
+                content: '',
+                format: 'line-break',
+              },
+              {
+                type: 'text',
+                content: 'Second line',
+                format: 'bold',
+              },
+            ],
+          },
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'text',
+                content: 'Third line',
+              },
+            ],
+          },
+        ],
+      ],
+    );
+  });
 });

--- a/ts-libs/md-parser/src/lib/reader-fns/generate-markdown-sections.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/generate-markdown-sections.ts
@@ -3,6 +3,7 @@ import { MarkdownType, SectionContentType } from '@peterjokumsen/ts-md-models';
 import { getSectionContentType } from '../helper-fns';
 import { readList } from './read-list';
 import { readParagraph } from './read-paragraph';
+import { readQuote } from './read-quote';
 import { readSection } from './read-section';
 
 /**
@@ -37,6 +38,12 @@ export function* generateMarkdownSections(
       }
       case 'paragraph': {
         const { result, lastLineIndex } = readParagraph(lines, idx);
+        idx = lastLineIndex;
+        next = result;
+        break;
+      }
+      case 'quote': {
+        const { result, lastLineIndex } = readQuote(lines, idx);
         idx = lastLineIndex;
         next = result;
         break;

--- a/ts-libs/md-parser/src/lib/reader-fns/read-quote.spec.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-quote.spec.ts
@@ -1,0 +1,101 @@
+import { MarkdownQuote } from '@peterjokumsen/ts-md-models';
+import { ReadResult } from '../_models';
+import { readParagraph } from './read-paragraph';
+import { readQuote } from './read-quote';
+
+jest.mock('./read-paragraph');
+
+describe('readQuote', () => {
+  describe('when line is not a quote', () => {
+    it('should throw an error', () => {
+      // Arrange
+      const lines = ['', 'abcd', ''];
+      const start = 1;
+
+      // Act
+      const act = () => readQuote(lines, start);
+
+      // Assert
+      expect(act).toThrow();
+    });
+  });
+
+  describe('when line has quote', () => {
+    let readParagraphSpy: jest.Mocked<typeof readParagraph>;
+
+    beforeEach(() => {
+      let number = 2;
+      readParagraphSpy = jest
+        .mocked(readParagraph)
+        .mockName('readParagraph')
+        .mockImplementation(() => ({
+          result: {
+            type: 'paragraph',
+            content: [],
+          },
+          lastLineIndex: number === 3 ? number + 4 : number++,
+        }));
+    });
+
+    it('should return a quote with paragraphs', () => {
+      // Arrange
+      const lines = ['> item 1', '> item 2', '> item 3', '>', '> item 4'];
+      const start = 0;
+
+      // Act
+      const result = readQuote(lines, start);
+
+      // Assert
+      const quoteLines = ['item 1', 'item 2', 'item 3', '', 'item 4'];
+      expect(readParagraphSpy).toHaveBeenCalledWith(quoteLines, 0);
+      expect(readParagraphSpy).toHaveBeenCalledWith(quoteLines, 4);
+      const expectedContent: MarkdownQuote = {
+        type: 'quote',
+        indent: 0,
+        paragraphs: [
+          {
+            type: 'paragraph',
+            content: [],
+          },
+          {
+            type: 'paragraph',
+            content: [],
+          },
+        ],
+      };
+      const expected: ReadResult<'quote'> = {
+        result: expectedContent,
+        lastLineIndex: 5,
+      };
+      expect(result).toEqual(expected);
+    });
+
+    it('should handle indents of quote result', () => {
+      // Arrange
+      const lines = ['  > item 1', '> item 2', '> item 3', '>', '> item 4'];
+      const start = 0;
+
+      // Act
+      const result = readQuote(lines, start);
+
+      // Assert
+      const quoteLines = ['item 1'];
+      expect(readParagraphSpy).toHaveBeenCalledWith(quoteLines, 0);
+      const expectedContent: MarkdownQuote = {
+        type: 'quote',
+        indent: 2,
+        paragraphs: [
+          {
+            type: 'paragraph',
+            content: [],
+          },
+        ],
+      };
+      const expected: ReadResult<'quote'> = {
+        result: expectedContent,
+        lastLineIndex: 1,
+      };
+      expect(result).toEqual(expected);
+    });
+  });
+});

--- a/ts-libs/md-parser/src/lib/reader-fns/read-quote.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-quote.ts
@@ -1,0 +1,61 @@
+import { MarkdownParagraph, MarkdownType } from '@peterjokumsen/ts-md-models';
+
+import { ReadResult } from '../_models';
+import { readParagraph } from './read-paragraph';
+
+/**
+ * Reads a quote block from the provided markdown lines.
+ * @param lines The markdown lines to read.
+ * @param start The line index to start reading.
+ * @returns The read quote block and the last line index read.
+ */
+export function readQuote(lines: string[], start: number): ReadResult<'quote'> {
+  let currentLineIdx = start;
+  const paragraphLines: string[] = [];
+  let indent: number | undefined = undefined;
+  for (; currentLineIdx < lines.length; currentLineIdx++) {
+    const match = lines[currentLineIdx].match(/(\s.)?>(\s?)(.*)/);
+    if (!match) {
+      if (currentLineIdx === start) {
+        throw new Error(`Line [${start}] "${lines[start]}" is not a quote`);
+      } else {
+        break;
+      }
+    }
+
+    const [, indentation, , line] = match;
+    const currentIndentation = indentation?.length ?? 0;
+    if (indent === undefined) {
+      indent = currentIndentation;
+    } else if (currentIndentation !== indent) {
+      break;
+    }
+
+    paragraphLines.push(line ?? '');
+  }
+
+  const paragraphs: MarkdownType<'paragraph' | 'horizontal-rule'>[] = [];
+  for (
+    let paragraphIdx = 0;
+    paragraphIdx < paragraphLines.length;
+    paragraphIdx++
+  ) {
+    if (!paragraphLines[paragraphIdx]) continue;
+    const { lastLineIndex, result } = readParagraph(
+      paragraphLines,
+      paragraphIdx,
+    );
+
+    paragraphIdx = lastLineIndex;
+    paragraphs.push(result);
+  }
+
+  return {
+    result: {
+      type: 'quote',
+      indent,
+      paragraphs,
+    },
+    lastLineIndex: currentLineIdx,
+  };
+}

--- a/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
+++ b/ts-libs/md-parser/src/lib/reader-fns/read-section.ts
@@ -9,6 +9,7 @@ import { readCodeBlock } from './read-code-block';
 import { readCommentedBlock } from './read-commented-block';
 import { readList } from './read-list';
 import { readParagraph } from './read-paragraph';
+import { readQuote } from './read-quote';
 
 /**
  * Reads a section starting from the specified start index in the provided lines from markdown file.
@@ -75,6 +76,12 @@ export function readSection(
       }
       case 'commented': {
         const { result, lastLineIndex } = readCommentedBlock(lines, i);
+        section.contents.push(result);
+        i = lastLineIndex;
+        break;
+      }
+      case 'quote': {
+        const { result, lastLineIndex } = readQuote(lines, i);
         section.contents.push(result);
         i = lastLineIndex;
         break;

--- a/ts-libs/md-parser/test-mds/quote.md
+++ b/ts-libs/md-parser/test-mds/quote.md
@@ -1,0 +1,11 @@
+# Quote example
+
+> This is a quote
+
+# Multi-line quote
+
+- List
+  > First line  
+  > **Second line**
+  >
+  > Third line


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Changes Made

- Added `readQuote` to consume all consecutive quote elements
- Updated readers to use `readQuote`

<!-- Optional Sections -->
<details>
<summary><strong>Expand for optional sections</strong></summary>

## Related issues

Work on #49

</details>
<!-- End of Optional Sections -->
