### PR TITLE
feat(ts-md-models): add `placement` property for image

### DIFF
--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -64,6 +64,7 @@ export interface MarkdownImage extends HasMarkdownContentType {
   type: 'image';
   src: string;
   alt: string;
+  placement?: 'begin' | 'center' | 'end' | 'full';
 }
 
 export interface MarkdownLink extends HasMarkdownContentType {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Added optional `placement` property to image model, with string literal values of `'begin' | 'center' | 'end' | 'full'`.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

Related to #32 

</details>
<!-- End of Additional details -->
