### PR TITLE
feat(md-parser): consume placement from query parameter in image URL

### DIFF
--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
@@ -25,13 +25,18 @@ describe('provideRegexTools', () => {
       'image',
       {
         shouldMatch: [
-          '[![alt-value](/src-value) link text](/href)',
+          '[![alt-value](/src-value?placement=end) link text](/href)',
           '![alt](/src)',
         ],
         shouldNotMatch: ['[link](/href)', 'random string'],
         expectedMatchFromFirstMatch: {
-          matched: '![alt-value](/src-value)',
-          content: { type: 'image', alt: 'alt-value', src: '/src-value' },
+          matched: '![alt-value](/src-value?placement=end)',
+          content: {
+            type: 'image',
+            alt: 'alt-value',
+            src: '/src-value',
+            placement: 'end',
+          },
         },
       },
     ],

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
@@ -1,4 +1,5 @@
 import {
+  ImagePlacementType,
   ParagraphContentType,
   SectionContentType,
 } from '@peterjokumsen/ts-md-models';
@@ -49,16 +50,22 @@ export function provideRegexTools<T extends RegexContentType>(
       };
     case 'image':
       return {
-        regex: /!\[(.*?)]\((.*?)\)/,
+        regex: /!\[(.*?)]\((.*?)(\??)(?:placement=(.+?))?\)/,
         contentFn: (regex) => {
-          const [matched, alt, src] = regex;
+          const [matched, alt, src, , placement] = regex;
+          const content: MatchedContent<'image'>['content'] = {
+            type: 'image',
+            alt,
+            src,
+          };
+
+          if (placement) {
+            content.placement = placement as ImagePlacementType;
+          }
+
           return {
             matched,
-            content: {
-              type: 'image',
-              alt,
-              src,
-            },
+            content,
           } as MatchedContent<T>;
         },
       };

--- a/ts-libs/ts-md-models/src/lib/image-placement-type.ts
+++ b/ts-libs/ts-md-models/src/lib/image-placement-type.ts
@@ -1,0 +1,1 @@
+export type ImagePlacementType = 'begin' | 'center' | 'end' | 'full';

--- a/ts-libs/ts-md-models/src/lib/index.ts
+++ b/ts-libs/ts-md-models/src/lib/index.ts
@@ -1,3 +1,4 @@
+export * from './image-placement-type';
 export * from './markdown-ast';
 export * from './markdown-content';
 export * from './markdown-content-type';

--- a/ts-libs/ts-md-models/src/lib/markdown-content.ts
+++ b/ts-libs/ts-md-models/src/lib/markdown-content.ts
@@ -1,3 +1,4 @@
+import { ImagePlacementType } from './image-placement-type';
 import { MarkdownContentType } from './markdown-content-type';
 import { MarkdownFormatType } from './markdown-format-type';
 import { ParagraphContentType } from './paragraph-content-type';
@@ -64,7 +65,7 @@ export interface MarkdownImage extends HasMarkdownContentType {
   type: 'image';
   src: string;
   alt: string;
-  placement?: 'begin' | 'center' | 'end' | 'full';
+  placement?: ImagePlacementType;
 }
 
 export interface MarkdownLink extends HasMarkdownContentType {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Updated parser to resolve image with URL using query parameter containing `placement=x` to use `x` as placement.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

Relates to #32 

</details>
<!-- End of Additional details -->
