### PR TITLE
fix(ng-services): improve image path resolution for markdown

### DIFF
--- a/ng-libs/services/src/lib/pj-markdown-client/services/markdown-parser.service.spec.ts
+++ b/ng-libs/services/src/lib/pj-markdown-client/services/markdown-parser.service.spec.ts
@@ -49,14 +49,17 @@ describe('MarkdownParserService', () => {
         ['./image.png', '/assets/doc/image.png'],
         ['../images/image.png', '/assets/images/image.png'],
         ['../../images/image.png', '/images/image.png'],
+        ['../other-images/a-image.png', '/assets/other-images/a-image.png'],
       ])(
         'should replace "%s" with "%s" when base path is "assets/doc"',
         (original, expected) => {
-          const markdownContent = `![alt](${original})`;
+          const markdownContent = `# Hello world\n\n![alt](${original})`;
 
           service.parse({ markdownContent, basePath: 'assets/doc' });
 
-          expect(parseMock).toHaveBeenCalledWith(`![alt](${expected})`);
+          expect(parseMock).toHaveBeenCalledWith(
+            expect.stringContaining(`![alt](${expected})`),
+          );
         },
       );
     });

--- a/ng-libs/services/src/lib/pj-markdown-client/services/markdown-parser.service.ts
+++ b/ng-libs/services/src/lib/pj-markdown-client/services/markdown-parser.service.ts
@@ -22,10 +22,12 @@ export class MarkdownParserService {
     markdownContent: string,
     basePath: string,
   ): string {
-    const regex = /!\[(.*)]\(((?:\.{1,2}\/)*)?(\w+\/)*(\w+.\w+)\)/g;
+    const regex = /!\[(.*)]\(((?:\.{1,2}\/)*)?(\w+\/)*(.*\.\w{3,4})\)/g;
     return markdownContent.replace(
       regex,
-      (_, altText, relativePath, folderPath, fileName) => {
+      (original, altText, relativePath, folderPath, fileName) => {
+        if (fileName?.startsWith('http')) return original;
+
         let base = basePath[0] === '/' ? basePath.slice(1) : basePath;
         if (typeof relativePath === 'string' && relativePath.includes('..')) {
           const baseParts = basePath.split('/').filter((p) => !!p);


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

After attempting to use `PjMarkdownClient`, found that images with `-` in filename are not correctly updated.

## Changes Made

Updated regular expression used to adjust paths for images.

## Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
