### PR TITLE
fix(blog): update `staging` configuration to generate service worker

### DIFF
--- a/apps/blog/project.json
+++ b/apps/blog/project.json
@@ -106,7 +106,9 @@
               "output": "/"
             }
           ],
-          "outputHashing": "all"
+          "outputHashing": "all",
+          "serviceWorker": "apps/blog/ngsw-config.json",
+          "appShell": true
         },
         "development": {
           "optimization": false,


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Updated `staging` build configuration (used for deployment in CI/CD workflow) to create service worker to prevent console error in lighthouse reports.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

Resolves #61

</details>
<!-- End of Additional details -->
