### PR TITLE
feat(blog): add route navigation animation

### DIFF
--- a/apps/blog/src/app/animations.ts
+++ b/apps/blog/src/app/animations.ts
@@ -1,0 +1,44 @@
+import {
+  animate,
+  animateChild,
+  group,
+  query,
+  style,
+  transition,
+  trigger,
+} from '@angular/animations';
+
+export function slideInAnimation(
+  triggerName: string,
+): ReturnType<typeof trigger> {
+  return trigger(triggerName, [
+    transition('* <=> *', [
+      style({ position: 'relative' }),
+      query(
+        ':enter, :leave',
+        [
+          style({
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: '100%',
+          }),
+        ],
+        { optional: true },
+      ),
+      query(':enter', [style({ left: '-100%' })], { optional: true }),
+      query(':leave', animateChild(), { optional: true }),
+      group([
+        query(
+          ':leave',
+          [animate('400ms ease-out', style({ left: '100%', opacity: 0 }))],
+          { optional: true },
+        ),
+        query(':enter', [animate('500ms ease-out', style({ left: '0%' }))], {
+          optional: true,
+        }),
+        query('@*', animateChild(), { optional: true }),
+      ]),
+    ]),
+  ]);
+}

--- a/apps/blog/src/app/primary.component.html
+++ b/apps/blog/src/app/primary.component.html
@@ -1,6 +1,6 @@
 <app-header [navElements]="navElements" />
 <div class="main-block">
-  <div class="content min-h-screen">
+  <div class="content min-h-screen" [@routeAnimations]="getAnimationContext()">
     <router-outlet></router-outlet>
   </div>
 </div>

--- a/apps/blog/src/app/primary.component.spec.ts
+++ b/apps/blog/src/app/primary.component.spec.ts
@@ -1,9 +1,16 @@
+import {
+  ActivatedRouteSnapshot,
+  ChildrenOutletContexts,
+  OutletContext,
+  Router,
+  RouterOutlet,
+} from '@angular/router';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MockComponent, MockDirective } from 'ng-mocks';
-import { Router, RouterOutlet } from '@angular/router';
 
 import { FooterComponent } from './components/footer';
 import { HeaderComponent } from './components/header';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { PjBrowserTools } from '@peterjokumsen/ng-services';
 import { PrimaryComponent } from './primary.component';
 import { of } from 'rxjs';
@@ -12,12 +19,18 @@ describe(`[blog] - ${PrimaryComponent.name}`, () => {
   let fixture: ComponentFixture<PrimaryComponent>;
   let component: PrimaryComponent;
 
+  let contextSpy: Partial<jest.Mocked<ChildrenOutletContexts>>;
+
   beforeEach(async () => {
+    contextSpy = {
+      getContext: jest.fn().mockName('getContext'),
+    };
     await TestBed.configureTestingModule({
-      imports: [PrimaryComponent],
+      imports: [PrimaryComponent, NoopAnimationsModule],
       providers: [
         { provide: PjBrowserTools, useValue: {} },
         { provide: Router, useValue: { events: of() } },
+        { provide: ChildrenOutletContexts, useValue: contextSpy },
       ],
     })
       .overrideComponent(PrimaryComponent, {
@@ -44,5 +57,35 @@ describe(`[blog] - ${PrimaryComponent.name}`, () => {
     expect(component.navElements).toEqual(
       expect.arrayContaining([{ route: '', title: 'Home' }]),
     );
+  });
+
+  describe('getAnimationContext', () => {
+    beforeEach(() => {
+      contextSpy.getContext?.mockReturnValue({
+        route: {
+          snapshot: {
+            data: { animation: 'something' },
+            url: [],
+          } as unknown as ActivatedRouteSnapshot,
+        },
+      } as unknown as OutletContext);
+    });
+
+    it('should return animation when available', () => {
+      expect(component.getAnimationContext()).toBe('something');
+    });
+
+    it('should return url when animation is not available', () => {
+      contextSpy.getContext?.mockReturnValue({
+        route: {
+          snapshot: {
+            data: {},
+            url: ['url'],
+          } as unknown as ActivatedRouteSnapshot,
+        },
+      } as unknown as OutletContext);
+
+      expect(component.getAnimationContext()).toEqual(['url']);
+    });
   });
 });

--- a/apps/blog/src/app/primary.component.ts
+++ b/apps/blog/src/app/primary.component.ts
@@ -1,9 +1,15 @@
+import {
+  ChildrenOutletContexts,
+  NavigationStart,
+  Route,
+  Router,
+  RouterOutlet,
+} from '@angular/router';
 import { Component, OnInit, inject } from '@angular/core';
 import {
   LoadingComponent,
   PjUiRouterNavigationElement,
 } from '@peterjokumsen/ui-elements';
-import { NavigationStart, Route, Router, RouterOutlet } from '@angular/router';
 import { PjBrowserTools, PjLogger } from '@peterjokumsen/ng-services';
 
 import { FooterComponent } from './components/footer';
@@ -11,6 +17,7 @@ import { HeaderComponent } from './components/header';
 import { childRoutes } from './app.routes';
 import { filter } from 'rxjs';
 import { pjFilterMap } from '@peterjokumsen/ts-utils';
+import { slideInAnimation } from './animations';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 
 @Component({
@@ -18,11 +25,13 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
   imports: [RouterOutlet, FooterComponent, HeaderComponent, LoadingComponent],
   templateUrl: './primary.component.html',
   styles: ``,
+  animations: [slideInAnimation('routeAnimations')],
 })
 export class PrimaryComponent implements OnInit {
   private _logger = inject(PjLogger, { optional: true });
   private _browserTools = inject(PjBrowserTools);
   private _router = inject(Router);
+  private _contexts = inject(ChildrenOutletContexts);
 
   private _navigationStart$ = this._router.events.pipe(
     filter(
@@ -53,5 +62,14 @@ export class PrimaryComponent implements OnInit {
       this._logger?.to.log('Navigation start: ', event);
       this._browserTools.window?.scrollTo({ top: 0, behavior: 'smooth' });
     });
+  }
+
+  getAnimationContext() {
+    const context = this._contexts.getContext('primary');
+    this._logger?.to.log('Primary context: ', context);
+    return (
+      context?.route?.snapshot?.data?.['animation'] ??
+      context?.route?.snapshot?.url
+    );
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Updated `primary` component to perform animations on routing navigation changes.

## Changes Made

For now just have a slide in animation, should be able to expand on this in the future.
Used [Angular tutorial](https://v17.angular.io/guide/route-animations) as an extremely helpful guide.

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

Closes #139 

</details>
<!-- End of Additional details -->
