### PR TITLE
fix(blog): only use router animation after initial load

### DIFF
--- a/apps/blog/src/app/primary.component.spec.ts
+++ b/apps/blog/src/app/primary.component.spec.ts
@@ -71,21 +71,31 @@ describe(`[blog] - ${PrimaryComponent.name}`, () => {
       } as unknown as OutletContext);
     });
 
-    it('should return animation when available', () => {
-      expect(component.getAnimationContext()).toBe('something');
+    it('should return null initially', () => {
+      expect(component.getAnimationContext()).toBeNull();
     });
 
-    it('should return url when animation is not available', () => {
-      contextSpy.getContext?.mockReturnValue({
-        route: {
-          snapshot: {
-            data: {},
-            url: ['url'],
-          } as unknown as ActivatedRouteSnapshot,
-        },
-      } as unknown as OutletContext);
+    describe('when called multiple times', () => {
+      beforeEach(() => {
+        component.getAnimationContext();
+      });
 
-      expect(component.getAnimationContext()).toEqual(['url']);
+      it('should return animation when available', () => {
+        expect(component.getAnimationContext()).toBe('something');
+      });
+
+      it('should return url when animation is not available', () => {
+        contextSpy.getContext?.mockReturnValue({
+          route: {
+            snapshot: {
+              data: {},
+              url: ['url'],
+            } as unknown as ActivatedRouteSnapshot,
+          },
+        } as unknown as OutletContext);
+
+        expect(component.getAnimationContext()).toEqual(['url']);
+      });
     });
   });
 });

--- a/apps/blog/src/app/primary.component.ts
+++ b/apps/blog/src/app/primary.component.ts
@@ -32,6 +32,7 @@ export class PrimaryComponent implements OnInit {
   private _browserTools = inject(PjBrowserTools);
   private _router = inject(Router);
   private _contexts = inject(ChildrenOutletContexts);
+  private _animations: string[] = [];
 
   private _navigationStart$ = this._router.events.pipe(
     filter(
@@ -65,11 +66,14 @@ export class PrimaryComponent implements OnInit {
   }
 
   getAnimationContext() {
+    const lastAnimation = this._animations.pop();
     const context = this._contexts.getContext('primary');
     this._logger?.to.log('Primary context: ', context);
-    return (
+    const nextAnimation =
       context?.route?.snapshot?.data?.['animation'] ??
-      context?.route?.snapshot?.url
-    );
+      context?.route?.snapshot?.url;
+    this._animations.push(nextAnimation);
+    if (!lastAnimation) return null;
+    return nextAnimation;
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Update logic for router animation, when no previous animation applied will not animate. 

## Changes Made

<!--
Describe the specific changes that have been made in this pull
request. Provide details on the approach taken to address the problem
and any notable implementation details.
-->

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Screenshots

<!--
If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily.
-->

## Related issues

Fixes #149
<!--
A link to any related issues or bugs that the pull request
addresses, connecting the code's context with the problem it
solves.
-->

## Testing instructions

<!--
Instructions on how to test the changes made in the pull
request, helping reviewers validate the code.
-->

</details>
<!-- End of Additional details -->
