### PR TITLE
fix(md-parser): update `code` parsing

### DIFF
--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.spec.ts
@@ -13,7 +13,7 @@ describe('provideRegexTools', () => {
     [
       'code',
       {
-        shouldMatch: ['`code`'],
+        shouldMatch: ['`code` line `other`', '`code`'],
         shouldNotMatch: ['random string', 'no ` close'],
         expectedMatchFromFirstMatch: {
           matched: '`code`',

--- a/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
+++ b/ts-libs/md-parser/src/lib/helper-fns/provide-regex-tools.ts
@@ -36,7 +36,7 @@ export function provideRegexTools<T extends RegexContentType>(
   switch (value) {
     case 'code':
       return {
-        regex: /`(.+)`/,
+        regex: /`(.+?)`/,
         contentFn: (regex) => {
           const [matched, content] = regex;
           return {

--- a/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
+++ b/ts-libs/md-parser/src/lib/parse-markdown.spec.ts
@@ -350,6 +350,40 @@ describe('parseMarkdown', () => {
           },
         ],
       ],
+      [
+        'Multiple inline code elements',
+        [
+          {
+            type: 'paragraph',
+            content: [
+              {
+                type: 'code',
+                element: 'This',
+              },
+              {
+                type: 'text',
+                content: ' line ',
+              },
+              {
+                type: 'code',
+                element: 'has',
+              },
+              {
+                type: 'text',
+                content: ' multiple ',
+              },
+              {
+                type: 'code',
+                element: 'inline code',
+              },
+              {
+                type: 'text',
+                content: ' elements.',
+              },
+            ],
+          },
+        ],
+      ],
     );
   });
 

--- a/ts-libs/md-parser/test-mds/inline-code.md
+++ b/ts-libs/md-parser/test-mds/inline-code.md
@@ -5,3 +5,7 @@ This is a paragraph with some `inline code` in it.
 # Inline code in link
 
 [This is a link with `inline code` in it](https://example.com).
+
+# Multiple inline code elements
+
+`This` line `has` multiple `inline code` elements.


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Summary

Resolve regular expression for reading `code` elements to be less greedy.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

Resolves #154

</details>
<!-- End of Additional details -->
