### PR TITLE
feat(.github): get affected projects when testing

### DIFF
--- a/.github/workflows/_workflow.jobs.cd.yml
+++ b/.github/workflows/_workflow.jobs.cd.yml
@@ -56,7 +56,7 @@ jobs:
     outputs:
       project_affected: ${{ steps.compare_affected.outputs.project_affected }}
     steps:
-      - name: 'Get affected applications 📦'
+      - name: 'Check ${{ inputs.project_name }} affected 📦'
         id: compare_affected
         run: |
           affected_projects="${{ inputs.affected_projects }}"

--- a/.github/workflows/_workflow.jobs.cd.yml
+++ b/.github/workflows/_workflow.jobs.cd.yml
@@ -18,6 +18,10 @@ on:
         description: 'Project name'
         required: true
         type: string
+      affected_projects:
+        description: 'Affected projects'
+        required: true
+        type: string
       # defaulted inputs:
       bicep_main_file:
         description: 'Bicep main file'
@@ -46,9 +50,32 @@ permissions:
   id-token: write
 
 jobs:
+  check_affected:
+    runs-on: ubuntu-latest
+    name: '🔍'
+    outputs:
+      project_affected: ${{ steps.compare_affected.outputs.project_affected }}
+    steps:
+      - name: 'Get affected applications 📦'
+        id: compare_affected
+        run: |
+          affected_projects="${{ inputs.affected_projects }}"
+          project_name="${{ inputs.project_name }}"
+          project_affected="No"
+
+          if [[ $affected_projects == *"$project_name"* ]]; then
+              project_affected="Yes"
+          fi
+
+          echo "output [project_affected=$project_affected]"
+          echo "project_affected=$project_affected" >> "$GITHUB_OUTPUT"
+
   # build the project when it is affected by the latest changes
   build_deploy:
+    needs: check_affected
     if: github.event.action != 'closed'
+      && needs.check_affected.outputs.project_affected == 'Yes'
+      || inputs.force_deploy
     runs-on: ubuntu-latest
     name: '🏭 & 🚀'
     env:
@@ -95,48 +122,20 @@ jobs:
 
       - name: 'Checkout 📥'
         uses: actions/checkout@v4
-        with:
-          # Number of commits to fetch. 0 indicates all history for all branches and tags.
-          fetch-depth: 0
-          submodules: true
 
       - name: 'Install dependencies 📦'
         uses: ./.github/actions/install-deps
 
-      - name: 'Set SHAs 📝'
-        id: set_base
-        uses: nrwl/nx-set-shas@v4
-
-      # Check if the project is affected by the latest changes
-      - name: 'Check if affected 🧪'
-        id: is_affected
-        run: |
-          echo "::group::nx show projects --type app --affected"
-          affected_projects=$(npx nx show projects --type app --affected)
-          echo "$affected_projects"
-          project_name="${{ inputs.project_name }}"
-          echo "::endgroup::"
-          project_affected="No"
-          echo ""
-          echo "Checking if $project_name is affected"
-          if [[ $affected_projects == *$project_name* ]]; then
-            project_affected="Yes"
-          fi
-
-          echo "output [project_affected=$project_affected]"
-          echo "project_affected=$project_affected" >> "$GITHUB_OUTPUT"
-
       # lint bicep files when a pull request is opened or synchronized
       - name: 'AZ CLI login 🔑'
         uses: azure/login@v2
-        if: steps.is_affected.outputs.project_affected == 'Yes'
         with:
           client-id: ${{ secrets.AZURE_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
 
       - name: 'Detect changes & validate 📝'
-        if: github.event_name != 'push' && steps.is_affected.outputs.project_affected == 'Yes'
+        if: github.event_name != 'push'
         id: static_web_app_what_if
         uses: azure/CLI@v2
         with:
@@ -155,7 +154,6 @@ jobs:
       - name: 'Deploy bicep 🚀'
         if: |
           ((github.event_name == 'push' && github.ref == 'refs/heads/main')
-          && steps.is_affected.outputs.project_affected == 'Yes')
           || inputs.force_deploy
         uses: azure/CLI@v2
         with:
@@ -168,7 +166,6 @@ jobs:
 
       # Build the project if it is affected
       - name: 'Build ${{ inputs.project_name }}'
-        if: steps.is_affected.outputs.project_affected == 'Yes'
         id: build_affected
         run: |
           echo "Setting up configuration for build step"
@@ -194,7 +191,6 @@ jobs:
 
       - name: 'Get SWA API key 🔑'
         id: static_web_app_apikey
-        if: steps.is_affected.outputs.project_affected == 'Yes'
         uses: azure/CLI@v2
         with:
           inlineScript: |

--- a/.github/workflows/_workflow.jobs.cd.yml
+++ b/.github/workflows/_workflow.jobs.cd.yml
@@ -153,7 +153,7 @@ jobs:
 
       - name: 'Deploy bicep 🚀'
         if: |
-          ((github.event_name == 'push' && github.ref == 'refs/heads/main')
+          (github.event_name == 'push' && github.ref == 'refs/heads/main')
           || inputs.force_deploy
         uses: azure/CLI@v2
         with:

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -67,10 +67,10 @@ jobs:
           comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
 
           # Remove any double commas that may have been introduced
-          comma_separated_projects=$(echo "${comma_separated_projects//s/,,*/,/g}")
+          comma_separated_projects=$("${comma_separated_projects//s/,,*/,/g}")
 
           # Remove a trailing comma if necessary
-          comma_separated_projects=$(echo "${comma_separated_projects//s/,$//}")
+          comma_separated_projects=$("${comma_separated_projects//s/,$//}")
 
           echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -67,10 +67,10 @@ jobs:
           comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
 
           # Remove any double commas that may have been introduced
-          comma_separated_projects=$(echo "$comma_separated_projects" | sed 's/,,*/,/g')
+          comma_separated_projects=$(echo "${comma_separated_projects//s/,,*/,/g}")
 
           # Remove a trailing comma if necessary
-          comma_separated_projects=$(echo "$comma_separated_projects" | sed 's/,$//')
+          comma_separated_projects=$(echo "${comma_separated_projects//s/,$//}")
 
           echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -18,6 +18,8 @@ on:
       CODECOV_TOKEN:
         description: 'Codecov Token'
         required: true
+    outputs:
+      projects_affected: ${{ jobs.test_and_lint.outputs.projects_affected }}
 
 permissions:
   id-token: write
@@ -32,6 +34,8 @@ jobs:
   test_and_lint:
     if: github.event.action != 'closed'
     runs-on: ubuntu-latest
+    outputs:
+      projects_affected: ${{ steps.get_affected.outputs.projects_affected }}
     name: 'Test & lint 🧪'
     steps:
       - name: 'Checkout 📥'
@@ -49,6 +53,19 @@ jobs:
       - name: 'Set SHAs 📝'
         id: set_base
         uses: nrwl/nx-set-shas@v4
+
+      # Check if the project is affected by the latest changes
+      - name: 'Get affected applications 📦'
+        id: get_affected
+        run: |
+          echo "::group::nx show projects --type app --affected"
+          affected_projects=$(npx nx show projects --type app --affected)
+          comma_separated=$(echo $affected_projects | tr '\n' ',')
+          echo "[ $affected_projects ] to $comma_separated"
+          echo "::endgroup::"
+
+          echo "output [projects_affected=$comma_separated]"
+          echo "projects_affected=$comma_separated" >> "$GITHUB_OUTPUT"
 
       - name: 'Check formatting 📐'
         run: npx nx format:check

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -66,12 +66,6 @@ jobs:
           # Replace newlines and spaces with commas
           comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
 
-          # Remove any double commas that may have been introduced
-          comma_separated_projects=$("${comma_separated_projects//s/,,*/,/g}")
-
-          # Remove a trailing comma if necessary
-          comma_separated_projects=$("${comma_separated_projects//s/,$//}")
-
           echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"
 

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -62,12 +62,21 @@ jobs:
         run: |
           echo "::group::nx show projects --type app --affected"
           affected_projects=$(npx nx show projects --type app --affected)
-          comma_separated=$(echo $affected_projects | tr '\n' ',')
-          echo "[ $affected_projects ] to $comma_separated"
+
+          # Replace newlines and spaces with commas
+          comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
+
+          # Remove any double commas that may have been introduced
+          comma_separated_projects=$(echo "$comma_separated_projects" | sed 's/,,*/,/g')
+
+          # Remove a trailing comma if necessary
+          comma_separated_projects=$(echo "$comma_separated_projects" | sed 's/,$//')
+
+          echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"
 
-          echo "output [projects_affected=$comma_separated]"
-          echo "projects_affected=$comma_separated" >> "$GITHUB_OUTPUT"
+          echo "output [projects_affected=$comma_separated_projects]"
+          echo "projects_affected=$comma_separated_projects" >> "$GITHUB_OUTPUT"
 
       - name: 'Check formatting 📐'
         run: npx nx format:check

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -67,10 +67,10 @@ jobs:
           comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
 
           # Remove any double commas that may have been introduced
-          comma_separated_projects=$(echo "${comma_separated_projects//s/,,*/,/g}")
+          comma_separated_projects=echo "${comma_separated_projects//s/,,*/,/g}"
 
           # Remove a trailing comma if necessary
-          comma_separated_projects=$(echo "${comma_separated_projects//s/,$//}")
+          comma_separated_projects=echo "${comma_separated_projects//s/,$//}"
 
           echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -19,7 +19,9 @@ on:
         description: 'Codecov Token'
         required: true
     outputs:
-      projects_affected: ${{ jobs.test_and_lint.outputs.projects_affected }}
+      projects_affected:
+        description: 'Comma separated list of affected projects'
+        value: ${{ jobs.test_and_lint.outputs.projects_affected }}
 
 permissions:
   id-token: write

--- a/.github/workflows/_workflow.jobs.ci.yml
+++ b/.github/workflows/_workflow.jobs.ci.yml
@@ -67,10 +67,10 @@ jobs:
           comma_separated_projects=$(echo "$affected_projects" | tr '\n' ',' | tr ' ' ',')
 
           # Remove any double commas that may have been introduced
-          comma_separated_projects=echo "${comma_separated_projects//s/,,*/,/g}"
+          comma_separated_projects=$(echo "${comma_separated_projects//s/,,*/,/g}")
 
           # Remove a trailing comma if necessary
-          comma_separated_projects=echo "${comma_separated_projects//s/,$//}"
+          comma_separated_projects=$(echo "${comma_separated_projects//s/,$//}")
 
           echo "[ $affected_projects ] to $comma_separated_projects"
           echo "::endgroup::"

--- a/.github/workflows/ci_cd.yml
+++ b/.github/workflows/ci_cd.yml
@@ -57,6 +57,7 @@ jobs:
       sub_domain: ${{ matrix.project.sub_domain }}
       audit_urls: ${{ matrix.project.audit_urls }}
       force_deploy: ${{ matrix.project.force_deployment }}
+      affected_projects: ${{ needs.lint_test_build.outputs.projects_affected }}
     secrets: inherit
 
   audit_deployed:


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Details

Moved step to check if project is affected by changes from CD workflow into CI workflow. Checking this before any checkout in CD process allows for quicker skip when project is not affected.

The CI workflow outputs all affected applications as a comma-separated string. And passes this output into CD process.

CD process has a new job which checks for the project name in the new `affected_projects` input from CI process. The build and deploy job depends on this new job, and will be skipped if the job failed to find the project.

### Improvements to handling affected projects:

* [`.github/workflows/_workflow.jobs.cd.yml`](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfR21-R24): Added a new input `affected_projects` and updated the `check_affected` job to determine if a project is affected by the latest changes. The `build_deploy` job now depends on the `check_affected` job and only runs if the project is affected or `force_deploy` is true. [[1]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfR21-R24) [[2]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfR53-R78)
* [`.github/workflows/_workflow.jobs.cd.yml`](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfL98-R138): Removed redundant steps for checking if a project is affected within the `build_deploy` job. [[1]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfL98-R138) [[2]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfL158) [[3]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfL171) [[4]](diffhunk://#diff-5d2d5523aa609da0f4aca508e5679ebb493f141329d1fd0dd7ff55b31cc840cfL197)

### Outputs for affected projects:

* [`.github/workflows/_workflow.jobs.ci.yml`](diffhunk://#diff-0ac98ed7fe183c1f81d4f37f880b8be8349329d6de9c3fdf8114f85ddb8c177cR21-R22): Added outputs for affected projects in the `test_and_lint` job and included a step to get affected applications. [[1]](diffhunk://#diff-0ac98ed7fe183c1f81d4f37f880b8be8349329d6de9c3fdf8114f85ddb8c177cR21-R22) [[2]](diffhunk://#diff-0ac98ed7fe183c1f81d4f37f880b8be8349329d6de9c3fdf8114f85ddb8c177cR37-R38) [[3]](diffhunk://#diff-0ac98ed7fe183c1f81d4f37f880b8be8349329d6de9c3fdf8114f85ddb8c177cR57-R69)
* [`.github/workflows/ci_cd.yml`](diffhunk://#diff-c80d54cb778b5196ee7b73e152870cac313eed095f65886e3f15247cdc900d1aR60): Updated the `affected_projects` input to use the output from the `lint_test_build` job.

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

<!--
A link to any related issues or bugs that the pull request
addresses, connecting the code's context with the problem it
solves.
-->

## Screenshots

<!--
If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily.
-->

## Testing instructions

<!--
Instructions on how to test the changes made in the pull
request, helping reviewers validate the code.
-->

</details>
<!-- End of Additional details -->
