### PR TITLE
feat(ttd): add loading indicator

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -40,6 +40,7 @@
     "evenodd",
     "fontawesome",
     "fortawesome",
+    "initialise",
     "lighthouseci",
     "markdownlintignore",
     "marocchino",

--- a/ng-libs/loading-indicator/.eslintrc.json
+++ b/ng-libs/loading-indicator/.eslintrc.json
@@ -1,0 +1,48 @@
+{
+  "extends": ["../../.eslintrc.json"],
+  "ignorePatterns": ["!**/*"],
+  "overrides": [
+    {
+      "files": ["*.ts"],
+      "extends": [
+        "plugin:@nx/angular",
+        "plugin:@angular-eslint/template/process-inline-templates"
+      ],
+      "rules": {
+        "@angular-eslint/directive-selector": [
+          "error",
+          {
+            "type": "attribute",
+            "prefix": "pj",
+            "style": "camelCase"
+          }
+        ],
+        "@angular-eslint/component-selector": [
+          "error",
+          {
+            "type": "element",
+            "prefix": "pj",
+            "style": "kebab-case"
+          }
+        ]
+      }
+    },
+    {
+      "files": ["*.html"],
+      "extends": ["plugin:@nx/angular-template"],
+      "rules": {}
+    },
+    {
+      "files": ["*.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": [
+          "error",
+          {
+            "ignoredFiles": ["{projectRoot}/eslint.config.{js,cjs,mjs}"]
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/ng-libs/loading-indicator/README.md
+++ b/ng-libs/loading-indicator/README.md
@@ -1,0 +1,7 @@
+# loading-indicator
+
+This library was generated with [Nx](https://nx.dev).
+
+## Running unit tests
+
+Run `nx test loading-indicator` to execute the unit tests.

--- a/ng-libs/loading-indicator/jest.config.ts
+++ b/ng-libs/loading-indicator/jest.config.ts
@@ -1,0 +1,21 @@
+export default {
+  displayName: 'loading-indicator',
+  preset: '../../jest.preset.js',
+  setupFilesAfterEnv: ['<rootDir>/src/test-setup.ts'],
+  coverageDirectory: '../../coverage/ng-libs/loading-indicator',
+  transform: {
+    '^.+\\.(ts|mjs|js|html)$': [
+      'jest-preset-angular',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+        stringifyContentPathRegex: '\\.(html|svg)$',
+      },
+    ],
+  },
+  transformIgnorePatterns: ['node_modules/(?!.*\\.mjs$)'],
+  snapshotSerializers: [
+    'jest-preset-angular/build/serializers/no-ng-attributes',
+    'jest-preset-angular/build/serializers/ng-snapshot',
+    'jest-preset-angular/build/serializers/html-comment',
+  ],
+};

--- a/ng-libs/loading-indicator/ng-package.json
+++ b/ng-libs/loading-indicator/ng-package.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../node_modules/ng-packagr/ng-package.schema.json",
+  "dest": "../../dist/ng-libs/loading-indicator",
+  "lib": {
+    "entryFile": "src/index.ts"
+  }
+}

--- a/ng-libs/loading-indicator/package.json
+++ b/ng-libs/loading-indicator/package.json
@@ -2,6 +2,7 @@
   "name": "@peterjokumsen/loading-indicator",
   "version": "0.0.1",
   "peerDependencies": {
+    "@angular/animations": "^18.2.0",
     "@angular/common": "^18.2.0",
     "@angular/core": "^18.2.0",
     "@angular/material": "^18.2.0"

--- a/ng-libs/loading-indicator/package.json
+++ b/ng-libs/loading-indicator/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "@peterjokumsen/loading-indicator",
+  "version": "0.0.1",
+  "peerDependencies": {
+    "@angular/common": "^18.2.0",
+    "@angular/core": "^18.2.0"
+  },
+  "sideEffects": false
+}

--- a/ng-libs/loading-indicator/package.json
+++ b/ng-libs/loading-indicator/package.json
@@ -3,7 +3,8 @@
   "version": "0.0.1",
   "peerDependencies": {
     "@angular/common": "^18.2.0",
-    "@angular/core": "^18.2.0"
+    "@angular/core": "^18.2.0",
+    "@angular/material": "^18.2.0"
   },
   "sideEffects": false
 }

--- a/ng-libs/loading-indicator/project.json
+++ b/ng-libs/loading-indicator/project.json
@@ -1,0 +1,36 @@
+{
+  "name": "loading-indicator",
+  "$schema": "../../node_modules/nx/schemas/project-schema.json",
+  "sourceRoot": "ng-libs/loading-indicator/src",
+  "prefix": "pj",
+  "projectType": "library",
+  "tags": [],
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:ng-packagr-lite",
+      "outputs": ["{workspaceRoot}/dist/{projectRoot}"],
+      "options": {
+        "project": "ng-libs/loading-indicator/ng-package.json"
+      },
+      "configurations": {
+        "production": {
+          "tsConfig": "ng-libs/loading-indicator/tsconfig.lib.prod.json"
+        },
+        "development": {
+          "tsConfig": "ng-libs/loading-indicator/tsconfig.lib.json"
+        }
+      },
+      "defaultConfiguration": "production"
+    },
+    "test": {
+      "executor": "@nx/jest:jest",
+      "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
+      "options": {
+        "jestConfig": "ng-libs/loading-indicator/jest.config.ts"
+      }
+    },
+    "lint": {
+      "executor": "@nx/eslint:lint"
+    }
+  }
+}

--- a/ng-libs/loading-indicator/src/index.ts
+++ b/ng-libs/loading-indicator/src/index.ts
@@ -1,1 +1,3 @@
+export * from './lib/provide-loading-indicator';
+export * from './lib/loading.service';
 export * from './lib/loading-indicator.component';

--- a/ng-libs/loading-indicator/src/index.ts
+++ b/ng-libs/loading-indicator/src/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/loading-indicator.component';

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
@@ -1,0 +1,22 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { LoadingIndicatorComponent } from './loading-indicator.component';
+
+describe('LoadingIndicatorComponent', () => {
+  let component: LoadingIndicatorComponent;
+  let fixture: ComponentFixture<LoadingIndicatorComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [LoadingIndicatorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoadingIndicatorComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { WritableSignal, signal } from '@angular/core';
 
 import { LoadingIndicatorComponent } from './loading-indicator.component';
+import { LoadingService } from './loading.service';
 
-describe('LoadingIndicatorComponent', () => {
+describe('LoadingIndicatorComponent without LoadingService', () => {
   let component: LoadingIndicatorComponent;
   let fixture: ComponentFixture<LoadingIndicatorComponent>;
 
@@ -13,10 +15,66 @@ describe('LoadingIndicatorComponent', () => {
 
     fixture = TestBed.createComponent(LoadingIndicatorComponent);
     component = fixture.componentInstance;
+  });
+
+  it('should throw an error', () => {
+    expect(() => component.ngOnInit()).toThrow(
+      expect.objectContaining({
+        message: expect.stringContaining('provideLoadingIndicator'),
+      }),
+    );
+  });
+});
+
+describe('LoadingIndicatorComponent', () => {
+  let component: LoadingIndicatorComponent;
+  let fixture: ComponentFixture<LoadingIndicatorComponent>;
+
+  let isLoadingSignal: WritableSignal<boolean>;
+  let loadingService: Pick<LoadingService, 'isLoading'>;
+
+  beforeEach(async () => {
+    isLoadingSignal = signal(false);
+    loadingService = {
+      isLoading: isLoadingSignal,
+    };
+
+    await TestBed.configureTestingModule({
+      providers: [
+        // keep split
+        { provide: LoadingService, useValue: loadingService },
+      ],
+      imports: [LoadingIndicatorComponent],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(LoadingIndicatorComponent);
+    component = fixture.componentInstance;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
+  });
+
+  describe('when isLoading is false', () => {
+    beforeEach(() => {
+      isLoadingSignal.update(() => false);
+      fixture.detectChanges();
+    });
+
+    it('should set display to none', () => {
+      expect(fixture.nativeElement.style.display).toBe('none');
+    });
+  });
+
+  describe('when isLoading is true', () => {
+    beforeEach(() => {
+      isLoadingSignal.update(() => true);
+      fixture.detectChanges();
+    });
+
+    it('should set display to block', () => {
+      expect(fixture.nativeElement.style.display).toBe('block');
+    });
   });
 });

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.spec.ts
@@ -1,8 +1,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { WritableSignal, signal } from '@angular/core';
 
+import { By } from '@angular/platform-browser';
 import { LoadingIndicatorComponent } from './loading-indicator.component';
 import { LoadingService } from './loading.service';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('LoadingIndicatorComponent without LoadingService', () => {
   let component: LoadingIndicatorComponent;
@@ -44,7 +46,7 @@ describe('LoadingIndicatorComponent', () => {
         // keep split
         { provide: LoadingService, useValue: loadingService },
       ],
-      imports: [LoadingIndicatorComponent],
+      imports: [NoopAnimationsModule, LoadingIndicatorComponent],
     }).compileComponents();
 
     fixture = TestBed.createComponent(LoadingIndicatorComponent);
@@ -56,14 +58,18 @@ describe('LoadingIndicatorComponent', () => {
     expect(component).toBeTruthy();
   });
 
+  function getLoadingContainer() {
+    return fixture.debugElement.query(By.css('.loading-indicator'));
+  }
+
   describe('when isLoading is false', () => {
     beforeEach(() => {
       isLoadingSignal.update(() => false);
       fixture.detectChanges();
     });
 
-    it('should set display to none', () => {
-      expect(fixture.nativeElement.style.display).toBe('none');
+    it('should hide ".loading-indicator"', () => {
+      expect(getLoadingContainer()).toBeFalsy();
     });
   });
 
@@ -73,8 +79,8 @@ describe('LoadingIndicatorComponent', () => {
       fixture.detectChanges();
     });
 
-    it('should set display to block', () => {
-      expect(fixture.nativeElement.style.display).toBe('block');
+    it('should display ".loading-indicator"', () => {
+      expect(getLoadingContainer()).toBeTruthy();
     });
   });
 });

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
@@ -4,6 +4,7 @@ import {
   OnInit,
   inject,
 } from '@angular/core';
+import { animate, style, transition, trigger } from '@angular/animations';
 
 import { CommonModule } from '@angular/common';
 import { LoadingService } from './loading.service';
@@ -14,15 +15,31 @@ import { MatProgressSpinner } from '@angular/material/progress-spinner';
   standalone: true,
   imports: [CommonModule, MatProgressSpinner],
   template: `
-    <div class="loading-indicator">
-      <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
-    </div>
+    @if (service?.isLoading()) {
+      <div class="loading-indicator" [@fadeInOut]>
+        @defer {
+          <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+        }
+      </div>
+    }
   `,
-  styles: ``,
+  styles: `
+    .loading-indicator {
+      position: fixed;
+      right: 1rem;
+      bottom: 1rem;
+    }
+  `,
   changeDetection: ChangeDetectionStrategy.OnPush,
-  host: {
-    '[style.display]': 'service?.isLoading() ? "block" : "none"',
-  },
+  animations: [
+    trigger('fadeInOut', [
+      transition(':enter', [
+        style({ transform: 'translateY(100%)' }),
+        animate('200ms', style({ transform: 'translateY(0)' })),
+      ]),
+      transition(':leave', [animate('500ms', style({ opacity: 0 }))]),
+    ]),
+  ],
 })
 export class LoadingIndicatorComponent implements OnInit {
   service = inject(LoadingService, { optional: true });

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
@@ -1,13 +1,41 @@
-import { ChangeDetectionStrategy, Component } from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  OnInit,
+  inject,
+} from '@angular/core';
 
 import { CommonModule } from '@angular/common';
+import { LoadingService } from './loading.service';
+import { MatProgressSpinner } from '@angular/material/progress-spinner';
 
 @Component({
   selector: 'pj-loading-indicator',
   standalone: true,
-  imports: [CommonModule],
-  template: `<p>loading-indicator works!</p>`,
+  imports: [CommonModule, MatProgressSpinner],
+  template: `
+    <div class="loading-indicator">
+      <mat-progress-spinner mode="indeterminate"></mat-progress-spinner>
+    </div>
+  `,
   styles: ``,
   changeDetection: ChangeDetectionStrategy.OnPush,
+  host: {
+    '[style.display]': 'service?.isLoading() ? "block" : "none"',
+  },
 })
-export class LoadingIndicatorComponent {}
+export class LoadingIndicatorComponent implements OnInit {
+  service = inject(LoadingService, { optional: true });
+
+  ngOnInit() {
+    if (!this.service) {
+      throw new Error(
+        [
+          'LoadingIndicatorComponent (pj-loading-indicator)',
+          'requires LoadingService to be provided,',
+          'use provideLoadingIndicator() from @peterjokumsen/loading-indicator',
+        ].join(' '),
+      );
+    }
+  }
+}

--- a/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
+++ b/ng-libs/loading-indicator/src/lib/loading-indicator.component.ts
@@ -1,0 +1,13 @@
+import { ChangeDetectionStrategy, Component } from '@angular/core';
+
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'pj-loading-indicator',
+  standalone: true,
+  imports: [CommonModule],
+  template: `<p>loading-indicator works!</p>`,
+  styles: ``,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class LoadingIndicatorComponent {}

--- a/ng-libs/loading-indicator/src/lib/loading.service.spec.ts
+++ b/ng-libs/loading-indicator/src/lib/loading.service.spec.ts
@@ -1,0 +1,64 @@
+import { LoadingService } from './loading.service';
+import { TestBed } from '@angular/core/testing';
+
+describe('LoadingService', () => {
+  let service: LoadingService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        // keep split
+        LoadingService,
+      ],
+    });
+    service = TestBed.inject(LoadingService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should initialise with isLoading as false', () => {
+    expect(service.isLoading()).toBeFalsy();
+  });
+
+  describe('when startLoading is called', () => {
+    beforeEach(() => {
+      service.startLoading();
+    });
+
+    it('should set isLoading to true', () => {
+      expect(service.isLoading()).toBeTruthy();
+    });
+
+    describe('and completeLoading is called', () => {
+      beforeEach(() => {
+        service.completeLoading();
+      });
+
+      it('should set isLoading to false', () => {
+        expect(service.isLoading()).toBeFalsy();
+      });
+    });
+  });
+
+  describe('when completeLoading is called', () => {
+    beforeEach(() => {
+      service.completeLoading();
+    });
+
+    it('should not set isLoading to false', () => {
+      expect(service.isLoading()).toBeFalsy();
+    });
+
+    describe('and startLoading is called', () => {
+      beforeEach(() => {
+        service.startLoading();
+      });
+
+      it('should set isLoading to true', () => {
+        expect(service.isLoading()).toBeTruthy();
+      });
+    });
+  });
+});

--- a/ng-libs/loading-indicator/src/lib/loading.service.ts
+++ b/ng-libs/loading-indicator/src/lib/loading.service.ts
@@ -1,0 +1,16 @@
+import { Injectable, computed, signal } from '@angular/core';
+
+@Injectable()
+export class LoadingService {
+  private _loadingCount = signal(0);
+
+  isLoading = computed(() => this._loadingCount() > 0);
+
+  startLoading() {
+    this._loadingCount.update((count) => count + 1);
+  }
+
+  completeLoading() {
+    this._loadingCount.update((count) => (count === 0 ? 0 : count - 1));
+  }
+}

--- a/ng-libs/loading-indicator/src/lib/provide-loading-indicator.spec.ts
+++ b/ng-libs/loading-indicator/src/lib/provide-loading-indicator.spec.ts
@@ -1,0 +1,19 @@
+import { LoadingService } from './loading.service';
+import { TestBed } from '@angular/core/testing';
+import { provideLoadingIndicator } from './provide-loading-indicator';
+
+describe('provideLoadingIndicator', () => {
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        // keep split
+        provideLoadingIndicator(),
+      ],
+    });
+  });
+
+  it('should provide LoadingService', () => {
+    const loadingService = TestBed.inject(LoadingService);
+    expect(loadingService).toBeTruthy();
+  });
+});

--- a/ng-libs/loading-indicator/src/lib/provide-loading-indicator.ts
+++ b/ng-libs/loading-indicator/src/lib/provide-loading-indicator.ts
@@ -1,0 +1,10 @@
+import { EnvironmentProviders, makeEnvironmentProviders } from '@angular/core';
+
+import { LoadingService } from './loading.service';
+
+export function provideLoadingIndicator(): EnvironmentProviders {
+  return makeEnvironmentProviders([
+    // keep split
+    LoadingService,
+  ]);
+}

--- a/ng-libs/loading-indicator/src/test-setup.ts
+++ b/ng-libs/loading-indicator/src/test-setup.ts
@@ -1,0 +1,9 @@
+// @ts-expect-error https://thymikee.github.io/jest-preset-angular/docs/getting-started/test-environment
+globalThis.ngJest = {
+  testEnvironmentOptions: {
+    errorOnUnknownElements: true,
+    errorOnUnknownProperties: true,
+  },
+};
+
+import 'jest-preset-angular/setup-jest';

--- a/ng-libs/loading-indicator/tsconfig.json
+++ b/ng-libs/loading-indicator/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "target": "es2022",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true
+  },
+  "files": [],
+  "include": [],
+  "references": [
+    {
+      "path": "./tsconfig.lib.json"
+    },
+    {
+      "path": "./tsconfig.spec.json"
+    }
+  ],
+  "extends": "../../tsconfig.base.json",
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/ng-libs/loading-indicator/tsconfig.lib.json
+++ b/ng-libs/loading-indicator/tsconfig.lib.json
@@ -1,0 +1,17 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "declaration": true,
+    "declarationMap": true,
+    "inlineSources": true,
+    "types": []
+  },
+  "exclude": [
+    "src/**/*.spec.ts",
+    "src/test-setup.ts",
+    "jest.config.ts",
+    "src/**/*.test.ts"
+  ],
+  "include": ["src/**/*.ts"]
+}

--- a/ng-libs/loading-indicator/tsconfig.lib.prod.json
+++ b/ng-libs/loading-indicator/tsconfig.lib.prod.json
@@ -1,0 +1,7 @@
+{
+  "extends": "./tsconfig.lib.json",
+  "compilerOptions": {
+    "declarationMap": false
+  },
+  "angularCompilerOptions": {}
+}

--- a/ng-libs/loading-indicator/tsconfig.spec.json
+++ b/ng-libs/loading-indicator/tsconfig.spec.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "../../dist/out-tsc",
+    "module": "commonjs",
+    "target": "es2016",
+    "types": ["jest", "node"]
+  },
+  "files": ["src/test-setup.ts"],
+  "include": [
+    "jest.config.ts",
+    "src/**/*.test.ts",
+    "src/**/*.spec.ts",
+    "src/**/*.d.ts"
+  ]
+}

--- a/ng-libs/task-management/package.json
+++ b/ng-libs/task-management/package.json
@@ -5,7 +5,8 @@
     "@angular/common": "^18.2.0",
     "@angular/core": "^18.2.0",
     "@angular/router": "^18.2.0",
-    "rxjs": "~7.8.0"
+    "rxjs": "~7.8.0",
+    "@peterjokumsen/loading-indicator": "*"
   },
   "sideEffects": false
 }

--- a/ng-libs/task-management/src/lib/lib.routes.ts
+++ b/ng-libs/task-management/src/lib/lib.routes.ts
@@ -1,10 +1,12 @@
 import { Route } from '@angular/router';
 import { TaskManagementComponent } from './task-management/task-management.component';
+import { provideLoadingIndicator } from '@peterjokumsen/loading-indicator';
 
 export const taskManagementRoutes: Route[] = [
   {
     path: '',
     component: TaskManagementComponent,
+    providers: [provideLoadingIndicator()],
     children: [
       {
         path: '',

--- a/ng-libs/task-management/src/lib/services/tasks-data.service.spec.ts
+++ b/ng-libs/task-management/src/lib/services/tasks-data.service.spec.ts
@@ -1,15 +1,28 @@
-import { TOGGLE_RESPONSE_DELAY, TasksDataService } from './tasks-data.service';
+import { Observable, firstValueFrom } from 'rxjs';
+import { RESPONSE_DELAY, TasksDataService } from './tasks-data.service';
 
+import { LoadingService } from '@peterjokumsen/loading-indicator';
+import { Task } from '../models';
 import { TestBed } from '@angular/core/testing';
 
 describe('TasksDataService', () => {
   let service: TasksDataService;
 
+  let loadingServiceMock: jest.Mocked<
+    Pick<LoadingService, 'startLoading' | 'completeLoading'>
+  >;
+
   beforeEach(() => {
+    loadingServiceMock = {
+      startLoading: jest.fn().mockName('startLoading'),
+      completeLoading: jest.fn().mockName('completeLoading'),
+    };
+
     TestBed.configureTestingModule({
       providers: [
         // keep split
-        { provide: TOGGLE_RESPONSE_DELAY, useValue: false },
+        { provide: RESPONSE_DELAY, useValue: false },
+        { provide: LoadingService, useValue: loadingServiceMock },
         TasksDataService,
       ],
     });
@@ -21,12 +34,25 @@ describe('TasksDataService', () => {
   });
 
   describe('getTasks', () => {
-    it('should return tasks', (done) => {
-      service.getTasks().subscribe((tasks) => {
-        expect(tasks).toBeTruthy();
-        expect(tasks.length).toBeGreaterThan(0);
-        done();
-      });
+    let result$: Observable<Task[]>;
+
+    beforeEach(() => {
+      result$ = service.getTasks();
+    });
+
+    it('should return tasks', async () => {
+      const tasks = await firstValueFrom(result$);
+      expect(tasks).toBeTruthy();
+      expect(tasks.length).toBeGreaterThan(0);
+    });
+
+    it('should start loading', () => {
+      expect(loadingServiceMock.startLoading).toHaveBeenCalledTimes(1);
+    });
+
+    it('should complete loading', async () => {
+      await firstValueFrom(result$);
+      expect(loadingServiceMock.completeLoading).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/ng-libs/task-management/src/lib/services/tasks-data.service.ts
+++ b/ng-libs/task-management/src/lib/services/tasks-data.service.ts
@@ -1,17 +1,19 @@
 import { Injectable, InjectionToken, inject } from '@angular/core';
 
+import { LoadingService } from '@peterjokumsen/loading-indicator';
 import { Observable } from 'rxjs';
 import { Task } from '../models';
 import { staticTasks } from './static-tasks';
 
-export const TOGGLE_RESPONSE_DELAY = new InjectionToken<boolean>(
+export const RESPONSE_DELAY = new InjectionToken<boolean>(
   'TOGGLE_RESPONSE_DELAY',
 );
 
 @Injectable()
 export class TasksDataService {
+  private _loadingService = inject(LoadingService);
   private _useResponseDelay =
-    inject(TOGGLE_RESPONSE_DELAY, { optional: true }) ?? true;
+    inject(RESPONSE_DELAY, { optional: true }) ?? true;
   private _instanceTasks: Task[] = [...staticTasks];
 
   private randomizeResponseTime<T>(value: T): Observable<T> {
@@ -19,12 +21,14 @@ export class TasksDataService {
     return new Observable((observer) => {
       setTimeout(() => {
         observer.next(value);
+        this._loadingService.completeLoading();
         observer.complete();
       }, timeout);
     });
   }
 
   getTasks(): Observable<Task[]> {
+    this._loadingService.startLoading();
     return this.randomizeResponseTime(this._instanceTasks);
   }
 }

--- a/ng-libs/task-management/src/lib/task-management/task-management.component.html
+++ b/ng-libs/task-management/src/lib/task-management/task-management.component.html
@@ -8,4 +8,6 @@
 
 <h2>Tasks</h2>
 
+<pj-loading-indicator></pj-loading-indicator>
+
 <router-outlet></router-outlet>

--- a/ng-libs/task-management/src/lib/task-management/task-management.component.spec.ts
+++ b/ng-libs/task-management/src/lib/task-management/task-management.component.spec.ts
@@ -1,5 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { LoadingIndicatorComponent } from '@peterjokumsen/loading-indicator';
+import { MockComponent } from 'ng-mocks';
 import { RouterModule } from '@angular/router';
 import { TaskManagementComponent } from './task-management.component';
 import { TasksDataService } from '../services';
@@ -19,7 +21,11 @@ describe('TaskManagementComponent', () => {
       imports: [TaskManagementComponent, RouterModule.forRoot([])],
     })
       .overrideComponent(TaskManagementComponent, {
-        set: {
+        remove: {
+          imports: [LoadingIndicatorComponent],
+        },
+        add: {
+          imports: [MockComponent(LoadingIndicatorComponent)],
           providers: [
             // keep split
             { provide: TasksDataService, useValue: tasksDataMock },

--- a/ng-libs/task-management/src/lib/task-management/task-management.component.ts
+++ b/ng-libs/task-management/src/lib/task-management/task-management.component.ts
@@ -2,12 +2,13 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { RouterLink, RouterOutlet } from '@angular/router';
 
 import { CommonModule } from '@angular/common';
+import { LoadingIndicatorComponent } from '@peterjokumsen/loading-indicator';
 import { TasksDataService } from '../services';
 
 @Component({
   selector: 'task-mgr-task-management',
   standalone: true,
-  imports: [CommonModule, RouterLink, RouterOutlet],
+  imports: [CommonModule, RouterLink, RouterOutlet, LoadingIndicatorComponent],
   providers: [TasksDataService],
   templateUrl: './task-management.component.html',
   styleUrl: './task-management.component.scss',

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -15,6 +15,9 @@
     "skipDefaultLibCheck": true,
     "baseUrl": ".",
     "paths": {
+      "@peterjokumsen/loading-indicator": [
+        "ng-libs/loading-indicator/src/index.ts"
+      ],
       "@peterjokumsen/md-parser": ["ts-libs/md-parser/src/index.ts"],
       "@peterjokumsen/md-renderer": ["ng-libs/md-renderer/src/index.ts"],
       "@peterjokumsen/ng-services": ["ng-libs/services/src/index.ts"],


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Details

Created `loading-indicator` library, which has `pj-loading-indicator` component and `LoadingService`. When calling `startLoading` function in `LoadingService`, will display progress spinner and after calling `completeLoading` function, will hide progress spinner.
