### PR TITLE
fix(md-renderer): update display of link and quote block

### DIFF
--- a/ng-libs/md-renderer/src/lib/components/md-link.component.spec.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-link.component.spec.ts
@@ -92,7 +92,7 @@ describe('MdLinkComponent', () => {
       });
 
       it('should set target as "_blank"', () => {
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ target: '_blank' }),
         );
       });
@@ -113,7 +113,7 @@ describe('MdLinkComponent', () => {
         };
         fixture.detectChanges();
 
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ target: '_self' }),
         );
       });
@@ -130,16 +130,16 @@ describe('MdLinkComponent', () => {
       });
 
       it('should set anchor', () => {
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ href: 'href-value' }),
         );
-        expect(component.anchor()?.content[0]).toEqual(
+        expect(component.currentAnchor()?.content[0]).toEqual(
           expect.objectContaining({ type: 'text', content: 'content-value' }),
         );
       });
 
       it('should include aria label', () => {
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ ariaLabel: 'content-value' }),
         );
       });
@@ -166,17 +166,17 @@ describe('MdLinkComponent', () => {
       });
 
       it('should set anchor', () => {
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ href: 'href-value' }),
         );
-        expect(component.anchor()?.content).toEqual([
+        expect(component.currentAnchor()?.content).toEqual([
           expect.objectContaining({ type: 'text', content: 'text' }),
           expect.objectContaining({ type: 'text', content: 'end' }),
         ]);
       });
 
       it('should include aria label', () => {
-        expect(component.anchor()).toEqual(
+        expect(component.currentAnchor()).toEqual(
           expect.objectContaining({ ariaLabel: 'text end' }),
         );
       });

--- a/ng-libs/md-renderer/src/lib/components/md-link.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-link.component.ts
@@ -4,7 +4,11 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { MarkdownContent, MarkdownType, mdModelCheck } from '@peterjokumsen/ts-md-models';
+import {
+  MarkdownContent,
+  MarkdownType,
+  mdModelCheck,
+} from '@peterjokumsen/ts-md-models';
 
 import { ExpectedContentTypes } from '../filter-content-types';
 import { HasContent } from '../has-content';
@@ -13,7 +17,10 @@ import { PjLogger } from '@peterjokumsen/ng-services';
 import { WithId } from '../models';
 import { logUnexpectedContent } from '../fns';
 
-type InnerAnchorTypes = Extract<ExpectedContentTypes, 'image' | 'text' | 'code'>;
+type InnerAnchorTypes = Extract<
+  ExpectedContentTypes,
+  'image' | 'text' | 'code'
+>;
 
 type MdAnchorContent = WithId<MarkdownType<'link' | InnerAnchorTypes>>;
 type MappedAnchor = Omit<MarkdownType<'link'>, 'content'> & {
@@ -50,12 +57,17 @@ type MappedAnchor = Omit<MarkdownType<'link'>, 'content'> & {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdLinkComponent implements HasContent<'link'> {
-  private static readonly _allowedContentTypes: Record<InnerAnchorTypes, unknown> = {
+  private static readonly _allowedContentTypes: Record<
+    InnerAnchorTypes,
+    unknown
+  > = {
     code: undefined,
     image: undefined,
     text: undefined,
   };
-  private static readonly _allowedTypes = Object.keys(MdLinkComponent._allowedContentTypes) as InnerAnchorTypes[];
+  private static readonly _allowedTypes = Object.keys(
+    MdLinkComponent._allowedContentTypes,
+  ) as InnerAnchorTypes[];
 
   private _mdContent = inject(MdContentService);
   private _logger = inject(PjLogger, { optional: true });
@@ -80,8 +92,12 @@ export class MdLinkComponent implements HasContent<'link'> {
     this.currentAnchor.update(() => newContent);
   }
 
-  private isAllowedContent(content: MarkdownContent): content is MarkdownType<InnerAnchorTypes> {
-    return MdLinkComponent._allowedTypes.includes(content.type as InnerAnchorTypes);
+  private isAllowedContent(
+    content: MarkdownContent,
+  ): content is MarkdownType<InnerAnchorTypes> {
+    return MdLinkComponent._allowedTypes.includes(
+      content.type as InnerAnchorTypes,
+    );
   }
 
   private getContents(parent: MarkdownType<'link'>): MdAnchorContent[] {

--- a/ng-libs/md-renderer/src/lib/components/md-link.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-link.component.ts
@@ -4,7 +4,7 @@ import {
   inject,
   signal,
 } from '@angular/core';
-import { MarkdownType, mdModelCheck } from '@peterjokumsen/ts-md-models';
+import { MarkdownContent, MarkdownType, mdModelCheck } from '@peterjokumsen/ts-md-models';
 
 import { ExpectedContentTypes } from '../filter-content-types';
 import { HasContent } from '../has-content';
@@ -13,7 +13,7 @@ import { PjLogger } from '@peterjokumsen/ng-services';
 import { WithId } from '../models';
 import { logUnexpectedContent } from '../fns';
 
-type InnerAnchorTypes = Extract<ExpectedContentTypes, 'image' | 'text'>;
+type InnerAnchorTypes = Extract<ExpectedContentTypes, 'image' | 'text' | 'code'>;
 
 type MdAnchorContent = WithId<MarkdownType<'link' | InnerAnchorTypes>>;
 type MappedAnchor = Omit<MarkdownType<'link'>, 'content'> & {
@@ -25,15 +25,20 @@ type MappedAnchor = Omit<MarkdownType<'link'>, 'content'> & {
 @Component({
   selector: 'pj-mdr-md-link',
   template: `
-    @if (anchor()) {
-      <a [href]="anchor()?.href" [attr.aria-label]="anchor()?.ariaLabel">
-        @for (content of anchor()?.content; track content.id) {
+    @let anchor = currentAnchor();
+    @if (anchor) {
+      <a
+        [href]="anchor.href"
+        [attr.aria-label]="anchor.ariaLabel"
+        [target]="anchor.target"
+      >
+        @for (content of anchor.content; track content.id) {
           <pj-mdr-md-wrapper
             [pjMdrMdContentInjection]="content"
           ></pj-mdr-md-wrapper>
         }
 
-        @if (anchor()?.target === '_blank') {
+        @if (anchor.target === '_blank') {
           <mat-icon aria-hidden="false" aria-label="Open in new tab">
             open_in_new
           </mat-icon>
@@ -45,10 +50,17 @@ type MappedAnchor = Omit<MarkdownType<'link'>, 'content'> & {
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class MdLinkComponent implements HasContent<'link'> {
+  private static readonly _allowedContentTypes: Record<InnerAnchorTypes, unknown> = {
+    code: undefined,
+    image: undefined,
+    text: undefined,
+  };
+  private static readonly _allowedTypes = Object.keys(MdLinkComponent._allowedContentTypes) as InnerAnchorTypes[];
+
   private _mdContent = inject(MdContentService);
   private _logger = inject(PjLogger, { optional: true });
 
-  anchor = signal<MappedAnchor | null>(null);
+  currentAnchor = signal<MappedAnchor | null>(null);
 
   set content(value: HasContent<'link'>['content']) {
     let newContent: MappedAnchor | null = null;
@@ -65,7 +77,11 @@ export class MdLinkComponent implements HasContent<'link'> {
       logUnexpectedContent('MdLinkComponent', value, this._logger?.to);
     }
 
-    this.anchor.update(() => newContent);
+    this.currentAnchor.update(() => newContent);
+  }
+
+  private isAllowedContent(content: MarkdownContent): content is MarkdownType<InnerAnchorTypes> {
+    return MdLinkComponent._allowedTypes.includes(content.type as InnerAnchorTypes);
   }
 
   private getContents(parent: MarkdownType<'link'>): MdAnchorContent[] {
@@ -74,19 +90,14 @@ export class MdLinkComponent implements HasContent<'link'> {
     }
 
     return parent.content.reduce((arr, content) => {
-      switch (content.type) {
-        case 'text':
-        case 'image':
-          arr.push(this._mdContent.mapContent(content));
-          break;
-
-        default:
-          this._logger?.to.error(
-            'Invalid content type "%s" for contents of MdLinkComponent, received %o',
-            content.type,
-            content,
-          );
-          break;
+      if (!this.isAllowedContent(content)) {
+        this._logger?.to.warn(
+          'Unsupported content type "%s" filtered out of %o',
+          content.type,
+          parent,
+        );
+      } else {
+        arr.push(this._mdContent.mapContent(content));
       }
 
       return arr;
@@ -102,6 +113,9 @@ export class MdLinkComponent implements HasContent<'link'> {
 
           case 'image':
             return c.alt;
+
+          case 'code':
+            return c.element;
 
           default:
             this._logger?.to.error(

--- a/ng-libs/md-renderer/src/lib/components/md-quote-block.component.ts
+++ b/ng-libs/md-renderer/src/lib/components/md-quote-block.component.ts
@@ -28,6 +28,7 @@ type MdParagraph = WithId<MarkdownType<'paragraph' | 'horizontal-rule'>>;
       display: block;
       padding: 1rem 0 0.2rem 1.5rem;
       border-left: 1px solid;
+      margin-bottom: 1rem;
     }
   `,
   changeDetection: ChangeDetectionStrategy.OnPush,


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Details

This pull request includes several updates to the `MdLinkComponent` in the `ng-libs/md-renderer` library, focusing on renaming methods, updating imports, and enhancing content handling. The changes also include a minor style update to the `MdQuoteBlockComponent`.

Key changes:

### Method Renaming:
* Renamed the `anchor` method to `currentAnchor` in `ng-libs/md-renderer/src/lib/components/md-link.component.ts` and updated all references in the corresponding test file `md-link.component.spec.ts`. [[1]](diffhunk://#diff-8310215a0f87e56ad89473bed64c118c38f179c5c018959aec18e1b081096d69L95-R95) [[2]](diffhunk://#diff-8310215a0f87e56ad89473bed64c118c38f179c5c018959aec18e1b081096d69L116-R116) [[3]](diffhunk://#diff-8310215a0f87e56ad89473bed64c118c38f179c5c018959aec18e1b081096d69L133-R142) [[4]](diffhunk://#diff-8310215a0f87e56ad89473bed64c118c38f179c5c018959aec18e1b081096d69L169-R179)

### Import Updates:
* Updated the imports in `md-link.component.ts` to include `MarkdownContent` and adjusted the `InnerAnchorTypes` type to include 'code'. [[1]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcL7-R11) [[2]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcL16-R23)

### Content Handling Enhancements:
* Added a static property `_allowedContentTypes` to define allowed content types and a method `isAllowedContent` to filter content based on these types. [[1]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcR60-R75) [[2]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcL68-R100)
* Modified the content processing logic to use the new `isAllowedContent` method and handle 'code' content type. [[1]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcL77-R116) [[2]](diffhunk://#diff-e45e287ebc3db024201fb8849935151494beda3139a3c1db870d5171f5da4cbcR133-R135)

### Template Update:
* Updated the template in `md-link.component.ts` to use the `currentAnchor` method and include the `target` attribute in the anchor tag.

### Style Update:
* Added a `margin-bottom` to the `.quote` class in `md-quote-block.component.ts` for improved spacing.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Related issues

#155 

<!--
A link to any related issues or bugs that the pull request
addresses, connecting the code's context with the problem it
solves.
-->

## Screenshots

<!--
If the changes are visual, including screenshots or GIFs can
help reviewers understand them more easily.
-->

## Testing instructions

<!--
Instructions on how to test the changes made in the pull
request, helping reviewers validate the code.
-->

</details>
<!-- End of Additional details -->
