### PR TITLE
chore(.github): update workflow

### DIFF
--- a/.github/lighthouse/lighthouse-report.parser.js
+++ b/.github/lighthouse/lighthouse-report.parser.js
@@ -20,6 +20,7 @@
 
 /**
  * @typedef {Object} LighthouseOutputs
+ * @prop {string} projectName
  * @prop {Record<string, string>} links
  * @prop {Manifest[]} manifest
  */
@@ -50,7 +51,7 @@ const summaryKeys = {
   accessibility: 'Accessibility',
   'best-practices': 'Best Practices',
   seo: 'SEO',
-  //  pwa: 'PWA',
+  pwa: 'PWA',
 };
 
 /** @param {number} rawScore */
@@ -100,7 +101,7 @@ const createMarkdownTableHeader = () => [
  * @param {CoreSummary} coreSummary
  * @returns {string}
  */
-const createLighthouseReport = ({ links, manifest }, coreSummary) => {
+const createLighthouseReport = ({ projectName, links, manifest }, coreSummary) => {
   const tableHeader = createMarkdownTableHeader();
   const tableBody = manifest.map((result) => {
     const testUrl = /** @type {string} */ (
@@ -115,7 +116,7 @@ const createLighthouseReport = ({ links, manifest }, coreSummary) => {
     });
   });
   const commentLines = [
-    `### ⚡️ Lighthouse report for the deploy preview of this PR`,
+    `### ⚡️ Lighthouse report for the deploy preview of ${projectName} in this PR`,
     '',
     ...tableHeader,
     ...tableBody,
@@ -138,6 +139,7 @@ module.exports = ({ lighthouseOutputs }, coreSummary) => {
 
 /** @type {LighthouseOutputs} */
 const _exampleOutputs = {
+  projectName: 'blog',
   links: {
     'https://url-to-test/': 'https://report.html',
   },

--- a/.github/lighthouse/lighthouse-report.parser.js
+++ b/.github/lighthouse/lighthouse-report.parser.js
@@ -101,7 +101,10 @@ const createMarkdownTableHeader = () => [
  * @param {CoreSummary} coreSummary
  * @returns {string}
  */
-const createLighthouseReport = ({ projectName, links, manifest }, coreSummary) => {
+const createLighthouseReport = (
+  { projectName, links, manifest },
+  coreSummary,
+) => {
   const tableHeader = createMarkdownTableHeader();
   const tableBody = manifest.map((result) => {
     const testUrl = /** @type {string} */ (

--- a/.github/workflows/_workflow.jobs.cd.yml
+++ b/.github/workflows/_workflow.jobs.cd.yml
@@ -266,7 +266,7 @@ jobs:
             const lighthouseCommentMaker = require('./.github/lighthouse/lighthouse-report.parser.js');
 
             const lighthouseOutputs = {
-              projectName: ${{ inputs.project_name }},
+              projectName: '${{ inputs.project_name }}',
               manifest: ${{ steps.lighthouse_audit.outputs.manifest }},
               links: ${{ steps.lighthouse_audit.outputs.links }},
             };

--- a/.github/workflows/_workflow.jobs.cd.yml
+++ b/.github/workflows/_workflow.jobs.cd.yml
@@ -266,6 +266,7 @@ jobs:
             const lighthouseCommentMaker = require('./.github/lighthouse/lighthouse-report.parser.js');
 
             const lighthouseOutputs = {
+              projectName: ${{ inputs.project_name }},
               manifest: ${{ steps.lighthouse_audit.outputs.manifest }},
               links: ${{ steps.lighthouse_audit.outputs.links }},
             };
@@ -275,7 +276,7 @@ jobs:
 
       - name: Add Lighthouse stats as comment ✍️
         id: comment_to_pr
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request' && steps.publish_swa.outputs.static_web_app_url != ''
         uses: marocchino/sticky-pull-request-comment@v2
         with:
           number: ${{ github.event.pull_request.number }}

--- a/.github/workflows/deploy-bullet-journal.yml
+++ b/.github/workflows/deploy-bullet-journal.yml
@@ -22,7 +22,6 @@ jobs:
     name: '🏗️ & 🚀'
     uses: './.github/workflows/_workflow.jobs.cd.yml'
     with:
-      force_deploy: true # to be reverted after initial deployment
       project_name: 'bullet-journal'
       build_location: 'dist/apps/bullet-journal'
       sub_domain: 'bullet-journal'


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Details

This pull request includes several changes to enhance the Lighthouse report parser and update workflow configurations. The most important changes are summarized below:

Enhancements to Lighthouse report parser:

* Added a new property `projectName` to the `LighthouseOutputs` typedef and updated related functions to include this new property. (`.github/lighthouse/lighthouse-report.parser.js`) [[1]](diffhunk://#diff-8787107ebf392520b169a2fd9643c1341631b33c81d802b6504fe94008cf3f70R23) [[2]](diffhunk://#diff-8787107ebf392520b169a2fd9643c1341631b33c81d802b6504fe94008cf3f70L103-R107) [[3]](diffhunk://#diff-8787107ebf392520b169a2fd9643c1341631b33c81d802b6504fe94008cf3f70L118-R122) [[4]](diffhunk://#diff-8787107ebf392520b169a2fd9643c1341631b33c81d802b6504fe94008cf3f70R145)
* Re-enabled the 'PWA' key in the `summaryKeys` object. (`.github/lighthouse/lighthouse-report.parser.js`)

Updates to workflow configurations:

* Modified the condition to add Lighthouse stats as a comment to ensure it only runs when the `static_web_app_url` is not empty. (`.github/workflows/_workflow.jobs.cd.yml`)
* Removed the `force_deploy` parameter from the `deploy-bullet-journal.yml` workflow configuration. (`.github/workflows/deploy-bullet-journal.yml`)