### PR TITLE
fix(bb-score): make no teams and -players text lighter

### DIFF
--- a/apps/bb-score/src/app/teams/team-detail/team-detail.component.ts
+++ b/apps/bb-score/src/app/teams/team-detail/team-detail.component.ts
@@ -138,7 +138,8 @@ import { TeamService } from '../team.service';
       .no-players {
         text-align: center;
         padding: 24px;
-        color: rgba(0, 0, 0, 0.54);
+        margin: 0;
+        color: var(--mat-sys-on-surface);
       }
 
       .players-list {

--- a/apps/bb-score/src/app/teams/teams-list/teams-list.component.ts
+++ b/apps/bb-score/src/app/teams/teams-list/teams-list.component.ts
@@ -37,9 +37,8 @@ import { TeamService } from '../team.service';
           @if (teams.length === 0) {
             <mat-card>
               <mat-card-content>
-                <p class="no-teams">
-                  No teams found. Create a team to get started.
-                </p>
+                <p class="no-teams">No teams found.</p>
+                <p class="no-teams">Create a team to get started.</p>
               </mat-card-content>
             </mat-card>
           } @else {
@@ -80,10 +79,20 @@ import { TeamService } from '../team.service';
         margin-bottom: 16px;
       }
 
+      mat-card > mat-card-content {
+        align-items: center;
+        display: flex;
+        flex-flow: column nowrap;
+        gap: 16px;
+        justify-content: center;
+        padding: 24px;
+      }
+
       .no-teams {
         text-align: center;
-        padding: 24px;
-        color: rgba(0, 0, 0, 0.54);
+        padding: 0;
+        margin: 0;
+        color: var(--mat-sys-on-surface);
       }
 
       .teams-list {


### PR DESCRIPTION
## Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Details

### Affected Components
- `apps/bb-score/src/app/teams/team-detail/team-detail.component.ts`
- `apps/bb-score/src/app/teams/teams-list/teams-list.component.ts`

### Changes
- Updated the color of the text stating that there are no teams and no players to `var(--mat-sys-on-surface)`.
This will make the text readable in light and dark mode.
- Update the text for no teams, to be in two paragraphs, one below the other. This offers a better reading experience to the user.

## Related issues

https://github.com/peterjokumsen/peterjokumsen-nx-workspace/issues/206

## Screenshots

![image](https://github.com/user-attachments/assets/e2d8c5fb-cbcc-4df4-a48a-04865af7b6cb)
![image](https://github.com/user-attachments/assets/5c8e002a-0bae-4a2f-a680-297da879813b)

## Testing instructions

1. checkout this branch
2. run `pnpm i`
3. run `npm run serve:bb-score`
4. navigate to [http://localhost:4200/teams](http://localhost:4200/teams)
   1. note that the `no teams` text is easily readable in light and dark mode
5. click on the blue `+` button to create a new team
6. fill in any details and click `Create Team`
7. click on the created team to open it
   1. note that the `no players` text is easily readable in light and dark mode
8. fin
