### PR TITLE
feat(bb-score): disable used positions for lineup

### DIFF
--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
@@ -1,0 +1,32 @@
+import { TestBed } from '@angular/core/testing';
+
+import { firstValueFrom } from 'rxjs';
+import { LineupService } from './lineup.service';
+
+describe('LineUpService', () => {
+  let service: LineupService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [LineupService],
+    });
+    service = TestBed.inject(LineupService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('disabledPositions$', () => {
+    it('should default with empty array', async () => {
+      const actual = await firstValueFrom(service.disabledPositions$);
+      expect(actual).toEqual([]);
+    });
+
+    it('should emit value passed in to updateDisabledPositions', async () => {
+      service.updateDisabledPositions(['P', 'CF']);
+      const actual = await firstValueFrom(service.disabledPositions$);
+      expect(actual).toEqual(['P', 'CF']);
+    });
+  });
+});

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.ts
@@ -1,0 +1,37 @@
+import { Injectable } from '@angular/core';
+import { BehaviorSubject } from 'rxjs';
+import { Position } from '../models';
+
+@Injectable()
+export class LineupService {
+  private _inUsePositions = new BehaviorSubject<Position[]>([]);
+  disabledPositions$ = this._inUsePositions.asObservable();
+
+  readonly fieldPositions: Array<{
+    value: Position;
+    label: string;
+    positionNumber: number;
+  }> = [
+    this.createPlayerLookup('P', 'Pitcher', 1),
+    this.createPlayerLookup('C', 'Catcher', 2),
+    this.createPlayerLookup('1', '1st Base', 3),
+    this.createPlayerLookup('2', '2nd Base', 4),
+    this.createPlayerLookup('3', '3rd Base', 5),
+    this.createPlayerLookup('SS', 'Shortstop', 6),
+    this.createPlayerLookup('LF', 'Left Field', 7),
+    this.createPlayerLookup('CF', 'Center Field', 8),
+    this.createPlayerLookup('RF', 'Right Field', 9),
+  ];
+
+  private createPlayerLookup(
+    value: Position,
+    label: string,
+    positionNumber: number,
+  ) {
+    return { value, label, positionNumber };
+  }
+
+  updateDisabledPositions(positions: Position[]): void {
+    this._inUsePositions.next(positions);
+  }
+}

--- a/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.html
+++ b/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.html
@@ -20,7 +20,7 @@
       matInput
       type="number"
       formControlName="playerNumber"
-      placeholder="Player #"
+      placeholder="#"
     />
   </mat-form-field>
 
@@ -49,9 +49,16 @@
     <mat-form-field appearance="outline" class="player-position">
       <mat-label>Position</mat-label>
       <mat-select formControlName="position">
+        @let positionsUsed = disabledPositions() ?? [];
         @for (position of fieldPositions; track position.value) {
-          <mat-option [value]="position.value">
-            {{ position.viewValue }}
+          <mat-option
+            [value]="position.value"
+            [disabled]="
+              positionsUsed.includes(position.value) &&
+              position.value !== playerPositionControl?.value
+            "
+          >
+            {{ position.label }}
           </mat-option>
         }
       </mat-select>


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Checklist

- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

## Details

- Updated player number placeholder to `#`
- Created `LineupService` to define positions and centralize positions already in use
- Updated `LineupEditComponent` to call `updateDisabledPositions` when starters updated
- Updated `PlayerSelectComponent` to disable position options that are already in use, except for the current player's position

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Screenshots

![image](https://github.com/user-attachments/assets/63b06e50-486e-4794-a1bc-d5fe11e16bfe)

</details>
<!-- End of Additional details -->
