### PR TITLE
fix(bb-score): make update toast show for new updates

### DIFF
--- a/apps/bb-score/src/app/core/components/update-toast/update-toast.component.ts
+++ b/apps/bb-score/src/app/core/components/update-toast/update-toast.component.ts
@@ -28,7 +28,7 @@ import { SwUpdateService } from '../../services/sw-update.service';
             <span>Updating...</span>
           }
           @case ('failed') {
-            <span>Something went wrong while updating</span>
+            <span>Something went wrong while updating...</span>
             <button mat-button color="primary" (click)="refresh()">
               Refresh
             </button>

--- a/apps/bb-score/src/app/core/models/index.ts
+++ b/apps/bb-score/src/app/core/models/index.ts
@@ -1,0 +1,1 @@
+export * from './update-status';

--- a/apps/bb-score/src/app/core/models/update-status.ts
+++ b/apps/bb-score/src/app/core/models/update-status.ts
@@ -1,0 +1,1 @@
+export type UpdateStatus = 'current' | 'updating' | 'updated' | 'failed';

--- a/apps/bb-score/src/app/core/services/sw-update.service.ts
+++ b/apps/bb-score/src/app/core/services/sw-update.service.ts
@@ -1,7 +1,8 @@
-import { Injectable, inject } from '@angular/core';
+import { inject, Injectable } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { SwUpdate } from '@angular/service-worker';
 import { BehaviorSubject } from 'rxjs';
+import { UpdateStatus } from '../models';
 
 @Injectable({
   providedIn: 'root',
@@ -9,9 +10,11 @@ import { BehaviorSubject } from 'rxjs';
 export class SwUpdateService {
   private _window = inject(Window, { optional: true }) ?? window;
   private _swUpdate = inject(SwUpdate);
-  private _updateAvailable = new BehaviorSubject<boolean>(false);
+  private _statusSubject = new BehaviorSubject<UpdateStatus>('current');
+  private _toastShowingSubject = new BehaviorSubject(false);
 
-  updateAvailable$ = this._updateAvailable.asObservable();
+  status$ = this._statusSubject.asObservable();
+  toastShowing$ = this._toastShowingSubject.asObservable();
 
   constructor() {
     if (!this._swUpdate.isEnabled) return;
@@ -19,16 +22,38 @@ export class SwUpdateService {
     this._swUpdate.versionUpdates
       .pipe(takeUntilDestroyed())
       .subscribe((event) => {
-        if (event.type === 'VERSION_READY') {
-          this._updateAvailable.next(true);
+        switch (event.type) {
+          case 'VERSION_READY':
+            this._statusSubject.next('updated');
+            break;
+          case 'VERSION_DETECTED':
+            this._statusSubject.next('updating');
+            break;
+          case 'VERSION_INSTALLATION_FAILED':
+            this._statusSubject.next('failed');
+            break;
+          default:
+            this._statusSubject.next('current');
         }
       });
   }
 
-  activateUpdate(): Promise<void> {
+  async activateUpdate(): Promise<void> {
     return this._swUpdate.activateUpdate().then(() => {
-      this._updateAvailable.next(false);
-      this._window.location.reload();
+      this._statusSubject.next('current');
+      this.refresh();
     });
+  }
+
+  refresh(): void {
+    this._window.location.reload();
+  }
+
+  openToast(): void {
+    this._toastShowingSubject.next(true);
+  }
+
+  dismissedToast(): void {
+    this._toastShowingSubject.next(false);
   }
 }


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Details

- Updated `SwUpdateService` to provide statuses and maintain whether toast is visible or not
- Updated `UpdateToastComponent`
  - Moved check from init to computed signal
  - Added display of different statuses
