### PR TITLE
feat(bb-score): disable players already in lineup

### DIFF
--- a/apps/bb-score/src/app/games/game-list/game-list.component.html
+++ b/apps/bb-score/src/app/games/game-list/game-list.component.html
@@ -56,7 +56,7 @@
         <app-game-card [game]="game">
           <mat-card-actions class="game-actions">
             <button mat-raised-button [routerLink]="['score', game.id]">
-              Score Game
+              Details
             </button>
             <button
               class="delete-game"

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
@@ -1,9 +1,14 @@
 <mat-accordion>
-  <mat-expansion-panel [expanded]="true">
+  <mat-expansion-panel [expanded]="missingStarters()">
     <mat-expansion-panel-header>
-      <mat-panel-title> Lineup </mat-panel-title>
+      <mat-panel-title [class]="{ urgent: missingStarters() }"> Lineup </mat-panel-title>
       <mat-panel-description>
-        <!-- TODO: set description for lineup... -->
+        Update lineup details
+        @if (missingStarters()) {
+          <span class="urgent">
+            , {{ missingStarters() }}
+          </span>
+        }
       </mat-panel-description>
     </mat-expansion-panel-header>
     <div class="lineup-container">

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
@@ -1,23 +1,41 @@
-<div class="game-lineup-container">
-  <h2>Game Lineup</h2>
+<mat-accordion>
+  <mat-expansion-panel [expanded]="true">
+    <mat-expansion-panel-header>
+      <mat-panel-title> Lineup </mat-panel-title>
+      <mat-panel-description>
+        <!-- TODO: set description for lineup... -->
+      </mat-panel-description>
+    </mat-expansion-panel-header>
+    <div class="lineup-container">
+      <mat-tab-group (selectedIndexChange)="onTeamTabChange($event)">
+        <mat-tab label="Home Team">
+          <app-lineup-edit
+            [team]="currentTeam$ | async"
+            [lineup]="homeLineup()"
+            (saveLineup)="saveLineup($event)"
+          >
+          </app-lineup-edit>
+        </mat-tab>
 
-  <mat-tab-group (selectedIndexChange)="onTeamTabChange($event)">
-    <mat-tab label="Home Team">
-      <app-lineup-edit
-        [team]="currentTeam$ | async"
-        [lineup]="homeLineup()"
-        (saveLineup)="saveLineup($event)"
-      >
-      </app-lineup-edit>
-    </mat-tab>
-
-    <mat-tab label="Away Team">
-      <app-lineup-edit
-        [team]="currentTeam$ | async"
-        [lineup]="awayLineup()"
-        (saveLineup)="saveLineup($event)"
-      >
-      </app-lineup-edit>
-    </mat-tab>
-  </mat-tab-group>
-</div>
+        <mat-tab label="Away Team">
+          <app-lineup-edit
+            [team]="currentTeam$ | async"
+            [lineup]="awayLineup()"
+            (saveLineup)="saveLineup($event)"
+          >
+          </app-lineup-edit>
+        </mat-tab>
+      </mat-tab-group>
+    </div>
+  </mat-expansion-panel>
+  <!--
+  <mat-expansion-panel>
+    <mat-expansion-panel-header>
+      <mat-panel-title> Self aware panel </mat-panel-title>
+      <mat-panel-description>
+      </mat-panel-description>
+    </mat-expansion-panel-header>
+    <p>I'm visible because I am open</p>
+  </mat-expansion-panel>
+  -->
+</mat-accordion>

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.html
@@ -1,13 +1,13 @@
 <mat-accordion>
-  <mat-expansion-panel [expanded]="missingStarters()">
+  <mat-expansion-panel [expanded]="expandLineup">
     <mat-expansion-panel-header>
-      <mat-panel-title [class]="{ urgent: missingStarters() }"> Lineup </mat-panel-title>
+      <mat-panel-title [class]="{ urgent: missingStarters() }">
+        Lineup
+      </mat-panel-title>
       <mat-panel-description>
         Update lineup details
         @if (missingStarters()) {
-          <span class="urgent">
-            , {{ missingStarters() }}
-          </span>
+          <span class="urgent"> , {{ missingStarters() }} </span>
         }
       </mat-panel-description>
     </mat-expansion-panel-header>
@@ -18,6 +18,7 @@
             [team]="currentTeam$ | async"
             [lineup]="homeLineup()"
             (saveLineup)="saveLineup($event)"
+            (lineupUpdate)="saveLineup($event, true)"
           >
           </app-lineup-edit>
         </mat-tab>
@@ -27,6 +28,7 @@
             [team]="currentTeam$ | async"
             [lineup]="awayLineup()"
             (saveLineup)="saveLineup($event)"
+            (lineupUpdate)="saveLineup($event, true)"
           >
           </app-lineup-edit>
         </mat-tab>

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.scss
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.scss
@@ -2,3 +2,7 @@
   margin: 0 auto;
   max-width: 1200px;
 }
+
+.urgent {
+  color: var(--mat-sys-error);
+}

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.scss
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.scss
@@ -1,30 +1,4 @@
-.game-lineup-container {
-  padding: 16px;
-  max-width: 800px;
+.lineup-container {
   margin: 0 auto;
-}
-
-.team-info {
-  display: flex;
-  gap: 16px;
-  margin-bottom: 24px;
-}
-
-.team-card {
-  flex: 1;
-  padding: 16px;
-  border-radius: 8px;
-  background-color: #f5f5f5;
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
-}
-
-.team-card h3 {
-  margin-top: 0;
-  color: #555;
-}
-
-.team-card p {
-  font-size: 18px;
-  font-weight: 500;
-  margin-bottom: 0;
+  max-width: 1200px;
 }

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
@@ -43,6 +43,23 @@ export class GameScoreManageComponent implements OnInit {
   homeLineup = computed(() => this._game()?.homeLineup);
   awayLineup = computed(() => this._game()?.awayLineup);
 
+  missingStarters = computed(() => {
+    const home =
+      this._game()?.homeLineup?.starters?.filter(
+        (s) => s.playerNumber || s.playerId,
+      ) ?? [];
+    const away =
+      this._game()?.awayLineup?.starters?.filter(
+        (s) => s.playerNumber || s.playerId,
+      ) ?? [];
+    if (home.length === 9 && away.length === 9) return null;
+    const messages = [
+      home.length !== 9 ? 'Home team is missing starting players' : null,
+      away.length !== 9 ? 'Away team is missing starting players' : null,
+    ];
+    return messages.filter((m) => m).join(' & ');
+  });
+
   currentTeam$: Observable<Team | null> = this._currentTeamIdSubject.pipe(
     switchMap((teamId) => {
       if (!teamId) return of(null);

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
@@ -42,6 +42,7 @@ export class GameScoreManageComponent implements OnInit {
   awayTeamName = computed(() => this._game()?.awayTeamName ?? '');
   homeLineup = computed(() => this._game()?.homeLineup);
   awayLineup = computed(() => this._game()?.awayLineup);
+  expandLineup = false;
 
   missingStarters = computed(() => {
     const home =
@@ -69,6 +70,7 @@ export class GameScoreManageComponent implements OnInit {
 
   ngOnInit() {
     this._currentTeamIdSubject.next(this.homeTeamId());
+    if (this.missingStarters()) this.expandLineup = true;
   }
 
   onTeamTabChange(index: number): void {
@@ -80,9 +82,10 @@ export class GameScoreManageComponent implements OnInit {
     }
   }
 
-  saveLineup(lineupData: Lineup | null): void {
+  saveLineup(lineupData: Lineup | null, hideMessage = false): void {
     const game = this._game();
     if (!game) {
+      if (hideMessage) return;
       this._snackBar.open('No game selected', 'Close', {
         duration: 3000,
       });
@@ -105,6 +108,9 @@ export class GameScoreManageComponent implements OnInit {
 
     // Save the updated game
     this._gameService.updateGame(updatedGame);
+    if (hideMessage) {
+      return;
+    }
 
     // Show success message
     const teamType = isHomeTeam ? 'Home' : 'Away';

--- a/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
+++ b/apps/bb-score/src/app/games/game-score/game-score-manage.component.ts
@@ -4,6 +4,7 @@ import { toSignal } from '@angular/core/rxjs-interop';
 import { MatBottomSheetModule } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
 import { MatCardModule } from '@angular/material/card';
+import { MatExpansionModule } from '@angular/material/expansion';
 import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTabsModule } from '@angular/material/tabs';
 import { BehaviorSubject, Observable, of, switchMap } from 'rxjs';
@@ -23,6 +24,7 @@ import { Lineup } from '../models';
     MatBottomSheetModule,
     MatSnackBarModule,
     LineupEditComponent,
+    MatExpansionModule,
   ],
   templateUrl: './game-score-manage.component.html',
   styleUrl: './game-score-manage.component.scss',

--- a/apps/bb-score/src/app/games/game.service.ts
+++ b/apps/bb-score/src/app/games/game.service.ts
@@ -1,6 +1,7 @@
 import { inject, Injectable } from '@angular/core';
-import { BehaviorSubject, first, map, Observable, tap } from 'rxjs';
+import { BehaviorSubject, first, map, Observable, switchMap, tap } from 'rxjs';
 import { Game } from './models';
+import { startWith } from 'rxjs/operators';
 
 const STORAGE_KEY = 'bb-score-games';
 
@@ -14,7 +15,14 @@ export class GameService {
   private _storage = inject(Storage, { optional: true }) ?? localStorage;
 
   games$ = this._gamesSubject.asObservable();
-  selectedGame$ = this._selectedGameSubject.asObservable();
+  selectedGame$ = this._selectedGameSubject.asObservable().pipe(
+    switchMap((game) =>
+      this.games$.pipe(
+        map((games) => games.find((g) => g.id === game?.id)),
+        startWith(game),
+      ),
+    ),
+  );
 
   private loadGames(): Game[] {
     const savedGames = this._storage.getItem(STORAGE_KEY);

--- a/apps/bb-score/src/app/games/game.service.ts
+++ b/apps/bb-score/src/app/games/game.service.ts
@@ -1,7 +1,7 @@
 import { inject, Injectable } from '@angular/core';
 import { BehaviorSubject, first, map, Observable, switchMap, tap } from 'rxjs';
-import { Game } from './models';
 import { startWith } from 'rxjs/operators';
+import { Game } from './models';
 
 const STORAGE_KEY = 'bb-score-games';
 

--- a/apps/bb-score/src/app/games/lineup-edit/lineup-edit.component.html
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup-edit.component.html
@@ -11,7 +11,7 @@
         <div [formGroupName]="i">
           <app-player-select
             [playerForm]="playerCtrl"
-            [label]="'Player ' + (i + 1)"
+            [label]="'Batting #' + (i + 1)"
             [isStarter]="true"
           ></app-player-select>
         </div>

--- a/apps/bb-score/src/app/games/lineup-edit/lineup-edit.component.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup-edit.component.ts
@@ -78,6 +78,7 @@ export class LineupEditComponent implements OnInit {
   }
 
   @Output() saveLineup = new EventEmitter<Lineup>();
+  @Output() lineupUpdate = new EventEmitter<Lineup>();
 
   lineupForm = this._fb.group({
     starters: this._fb.array(
@@ -100,6 +101,15 @@ export class LineupEditComponent implements OnInit {
     return arr.controls as FormGroup[];
   }
 
+  private subscribeToSaveValueChanges(): void {
+    this.lineupForm.valueChanges
+      .pipe(takeUntilDestroyed(this._destroyRef), debounceTime(500))
+      .subscribe((value) => {
+        console.log('lineupUpdate', value);
+        this.lineupUpdate.emit(value as Lineup);
+      });
+  }
+
   ngOnInit(): void {
     const positionValueChanges: Observable<Position | null>[] = [];
     for (const ctrl of this.starterFormGroups.map((c) => c.controls.position)) {
@@ -117,6 +127,8 @@ export class LineupEditComponent implements OnInit {
       .subscribe((positions) => {
         this._lineupSvc.updateDisabledPositions(positions.filter((p) => !!p));
       });
+
+    this.subscribeToSaveValueChanges();
   }
 
   createStarterPlayerFormGroup(init?: StartingPlayer) {

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
@@ -1,9 +1,9 @@
 import { TestBed } from '@angular/core/testing';
 
 import { BehaviorSubject, firstValueFrom } from 'rxjs';
-import { LineupService } from './lineup.service';
 import { GameService } from '../game.service';
 import { Game, StartingPlayer } from '../models';
+import { LineupService } from './lineup.service';
 
 describe('LineUpService', () => {
   let service: LineupService;

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
@@ -29,4 +29,23 @@ describe('LineUpService', () => {
       expect(actual).toEqual(['P', 'CF']);
     });
   });
+
+  describe('playersUsed$', () => {
+    it('should default with empty array', async () => {
+      const actual = await firstValueFrom(service.playerIdsUsed$);
+      expect(actual).toEqual([]);
+    });
+
+    it('should emit value passed in to updatePlayersUsed', async () => {
+      service.updatePlayersUsed({
+        starters: [{ playerId: 'id-1', playerNumber: '123', position: 'P' }],
+        bench: [
+          { playerId: 'id-2', playerNumber: '23' },
+          { playerId: 'id-3', playerNumber: '321' },
+        ],
+      });
+      const actual = await firstValueFrom(service.playerIdsUsed$);
+      expect(actual).toEqual(expect.arrayContaining(['id-3', 'id-2', 'id-1']));
+    });
+  });
 });

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
@@ -1,14 +1,38 @@
 import { TestBed } from '@angular/core/testing';
 
-import { firstValueFrom } from 'rxjs';
+import { BehaviorSubject, firstValueFrom } from 'rxjs';
 import { LineupService } from './lineup.service';
+import { GameService } from '../game.service';
+import { Game, StartingPlayer } from '../models';
 
 describe('LineUpService', () => {
   let service: LineupService;
+  let gameService: jest.Mocked<Pick<GameService, 'selectedGame$'>>;
+  let gameSubject: BehaviorSubject<Game>;
 
   beforeEach(() => {
+    const initialGame: Game = {
+      awayLineup: undefined,
+      awayTeamId: undefined,
+      awayTeamName: '',
+      date: new Date(),
+      homeLineup: undefined,
+      homeTeamId: undefined,
+      homeTeamName: '',
+      id: '',
+      league: '',
+      status: 'pending',
+    };
+    gameSubject = new BehaviorSubject<Game>(initialGame);
+    gameService = {
+      selectedGame$: gameSubject.asObservable(),
+    };
     TestBed.configureTestingModule({
-      providers: [LineupService],
+      providers: [
+        { provide: GameService, useValue: gameService },
+        // actual
+        LineupService,
+      ],
     });
     service = TestBed.inject(LineupService);
   });
@@ -17,35 +41,63 @@ describe('LineUpService', () => {
     expect(service).toBeTruthy();
   });
 
+  function prepareGame() {
+    gameSubject.next({
+      ...gameSubject.value,
+      homeLineup: {
+        starters: [
+          { playerId: 'id-1', playerNumber: '123', position: 'P' },
+          { playerId: 'id-2', playerNumber: '23', position: 'CF' },
+          {} as StartingPlayer,
+        ],
+        bench: [{ playerId: 'id-3', playerNumber: '321' }],
+      },
+      awayLineup: {
+        starters: [
+          { playerId: 'id-4', playerNumber: '123', position: '1' },
+          { playerId: 'id-5', playerNumber: '23', position: '2' },
+          {} as StartingPlayer,
+        ],
+        bench: [{ playerId: 'id-6', playerNumber: '321' }],
+      },
+    });
+  }
+
   describe('disabledPositions$', () => {
-    it('should default with empty array', async () => {
-      const actual = await firstValueFrom(service.disabledPositions$);
-      expect(actual).toEqual([]);
+    beforeEach(() => {
+      prepareGame();
     });
 
-    it('should emit value passed in to updateDisabledPositions', async () => {
-      service.updateDisabledPositions(['P', 'CF']);
+    it('should default using home team lineup', async () => {
       const actual = await firstValueFrom(service.disabledPositions$);
       expect(actual).toEqual(['P', 'CF']);
+    });
+
+    describe('when side changed', () => {
+      it('should use away team lineup', async () => {
+        service.sideChanged('away');
+        const actual = await firstValueFrom(service.disabledPositions$);
+        expect(actual).toEqual(['1', '2']);
+      });
     });
   });
 
   describe('playersUsed$', () => {
-    it('should default with empty array', async () => {
-      const actual = await firstValueFrom(service.playerIdsUsed$);
-      expect(actual).toEqual([]);
+    beforeEach(() => {
+      prepareGame();
     });
 
-    it('should emit value passed in to updatePlayersUsed', async () => {
-      service.updatePlayersUsed({
-        starters: [{ playerId: 'id-1', playerNumber: '123', position: 'P' }],
-        bench: [
-          { playerId: 'id-2', playerNumber: '23' },
-          { playerId: 'id-3', playerNumber: '321' },
-        ],
-      });
+    it('should default using home team lineup', async () => {
       const actual = await firstValueFrom(service.playerIdsUsed$);
-      expect(actual).toEqual(expect.arrayContaining(['id-3', 'id-2', 'id-1']));
+      expect(actual).toEqual(['id-1', 'id-2', 'id-3']);
+    });
+
+    describe('when side changed', () => {
+      it('should use away team lineup', async () => {
+        service.sideChanged('away');
+        const actual = await firstValueFrom(service.playerIdsUsed$);
+        expect(actual).toEqual(['id-4', 'id-5', 'id-6']);
+      });
     });
   });
 });

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.ts
@@ -1,11 +1,13 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject } from 'rxjs';
-import { Position } from '../models';
+import { Lineup, Position } from '../models';
 
 @Injectable()
 export class LineupService {
+  private _playerIdsUsed = new BehaviorSubject<string[]>([]);
   private _inUsePositions = new BehaviorSubject<Position[]>([]);
   disabledPositions$ = this._inUsePositions.asObservable();
+  playerIdsUsed$ = this._playerIdsUsed.asObservable();
 
   readonly fieldPositions: Array<{
     value: Position;
@@ -33,5 +35,15 @@ export class LineupService {
 
   updateDisabledPositions(positions: Position[]): void {
     this._inUsePositions.next(positions);
+  }
+
+  updatePlayersUsed(lineup: Partial<Lineup>): void {
+    const starterIds = (lineup?.starters
+      ?.map((s) => s.playerId)
+      .filter((pId) => !!pId) ?? []) as string[];
+    const benchIds = (lineup?.bench
+      ?.map((b) => b.playerId)
+      .filter((pId) => !!pId) ?? []) as string[];
+    this._playerIdsUsed.next([...starterIds, ...benchIds]);
   }
 }

--- a/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.html
+++ b/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.html
@@ -1,17 +1,19 @@
 <div class="title">
   <span class="header">{{ label }}</span>
-  <span class="spacer"></span>
-  <button
-    matSuffix
-    mat-raised-button
-    color="primary"
-    type="button"
-    (click)="addNewPlayer()"
-    tabindex="-1"
-  >
-    <mat-icon>add_circle</mat-icon>
-    Add New Player
-  </button>
+  @if (!playerIdControl?.value) {
+    <span class="spacer"></span>
+    <button
+      matSuffix
+      mat-raised-button
+      color="primary"
+      type="button"
+      (click)="addNewPlayer()"
+      tabindex="-1"
+    >
+      <mat-icon>add_circle</mat-icon>
+      Add New Player
+    </button>
+  }
 </div>
 <div [formGroup]="playerForm" class="player-select-container">
   <mat-form-field appearance="outline" class="player-number">
@@ -24,20 +26,28 @@
     />
   </mat-form-field>
 
-  <mat-form-field appearance="outline" class="player-select">
+  <mat-form-field
+    [formGroup]="playerFilterFormGroup"
+    appearance="outline"
+    class="player-select"
+  >
     <mat-label>Name</mat-label>
     <input
       matInput
-      formControlName="playerId"
+      formControlName="searchPlayer"
       [matAutocomplete]="playerAuto"
       placeholder="Type player name or number to find player"
     />
+    @let playersInUse = playerIdsInUse() ?? [];
     <mat-autocomplete
       #playerAuto="matAutocomplete"
       [displayWith]="displayFn.bind(this)"
     >
       @for (player of filteredPlayers$ | async; track player.id) {
-        <mat-option [value]="player.id">
+        <mat-option
+          [value]="player.id"
+          [disabled]="playersInUse.includes(player.id)"
+        >
           {{ player.name }}
           {{ player.number ? '#' + player.number : '' }}
         </mat-option>

--- a/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/player-select/player-select.component.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
-import { Component, inject, Input, OnChanges, OnInit } from '@angular/core';
+import { Component, inject, Input, OnInit } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
-import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MatAutocompleteModule } from '@angular/material/autocomplete';
 import { MatBottomSheet } from '@angular/material/bottom-sheet';
 import { MatButtonModule } from '@angular/material/button';
@@ -29,20 +29,32 @@ import { LineupService } from '../lineup.service';
   templateUrl: './player-select.component.html',
   styleUrl: './player-select.component.scss',
 })
-export class PlayerSelectComponent implements OnInit, OnChanges {
+export class PlayerSelectComponent implements OnInit {
   private _bottomSheet = inject(MatBottomSheet);
   private _lineupService = inject(LineupService);
   private _teamService = inject(TeamService);
+  private _fb = inject(FormBuilder);
 
   team = toSignal(this._teamService.selectedTeam$);
   @Input() playerForm!: FormGroup;
   @Input() label = 'Player';
   @Input() isStarter = false;
 
+  playerFilterFormGroup = this._fb.group({
+    searchPlayer: [''],
+  });
+
   fieldPositions = this._lineupService.fieldPositions;
   disabledPositions = toSignal(this._lineupService.disabledPositions$);
+  playerIdsInUse = toSignal(this._lineupService.playerIdsUsed$);
 
-  filteredPlayers$!: Observable<Player[]>;
+  filteredPlayers$: Observable<Player[]> =
+    this.playerFilterFormGroup.controls.searchPlayer.valueChanges.pipe(
+      map((value) => {
+        if ((value ?? '').length >= 1) return this.filterPlayers(value);
+        return [];
+      }),
+    );
 
   get playerIdControl() {
     return this.playerForm.get('playerId');
@@ -61,25 +73,6 @@ export class PlayerSelectComponent implements OnInit, OnChanges {
     this.playerNumberControl.patchValue(playerNumber ?? null);
   }
 
-  private initFilteredPlayers(): void {
-    if (this.playerIdControl) {
-      this.filteredPlayers$ = this.playerIdControl.valueChanges.pipe(
-        map((value) => (value?.length >= 1 ? this.filterPlayers(value) : [])),
-      );
-
-      // Listen for player selection changes to update number and position
-      this.playerIdControl.valueChanges.subscribe((playerId) => {
-        if (playerId && typeof playerId === 'string' && this.team()?.players) {
-          const selectedPlayer = this.team()?.players.find(
-            (p) => p.id === playerId,
-          );
-          if (!this.playerNumberControl) return;
-          this.updatePlayerNumber(selectedPlayer?.number);
-        }
-      });
-    }
-  }
-
   private filterPlayers(value: string | null): Player[] {
     if (!this.team() || !this.team()?.players) {
       return [];
@@ -96,14 +89,11 @@ export class PlayerSelectComponent implements OnInit, OnChanges {
     );
   }
 
-  ngOnInit(): void {
-    this.initFilteredPlayers();
-  }
-
-  ngOnChanges(): void {
-    if (this.team() && this.playerForm) {
-      this.initFilteredPlayers();
-    }
+  ngOnInit() {
+    this.playerFilterFormGroup.controls.searchPlayer.patchValue(
+      this.playerIdControl?.value ?? '',
+      { emitEvent: false },
+    );
   }
 
   displayFn(playerId: string): string {
@@ -112,6 +102,10 @@ export class PlayerSelectComponent implements OnInit, OnChanges {
     }
 
     const player = this.team()?.players.find((p) => p.id === playerId);
+    if (player && this.playerIdControl?.value !== playerId) {
+      this.playerIdControl?.patchValue(player.id);
+    }
+
     return player
       ? player.name + (player.number ? ' #' + player.number : '')
       : '';

--- a/apps/bb-score/src/app/games/models/game.ts
+++ b/apps/bb-score/src/app/games/models/game.ts
@@ -6,7 +6,7 @@ export interface GamePlayer {
 export type Position = 'P' | 'C' | '1' | '2' | '3' | 'SS' | 'LF' | 'CF' | 'RF';
 
 export interface StartingPlayer extends GamePlayer {
-  position: Position;
+  position?: Position;
 }
 
 export interface Lineup {


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Details

- Updated label for button to open game details
- Updated `GameScoreManageComponent` to display lineup in an expansion panel.
- Updated the lineup panel to display warnings when starters are incomplete.
- Updated `GameService` to ensure `selectedGame$` always emits latest game details
- Updated lineup editing to save on value change without showing toast
- Updated `LineupService` to record player Ids in use in the lineup
- Updated `LineupService` to drive values from current game, and added `playerIdUsed$` to provide players currently used in lineup
- Streamlined player filtering logic by introducing a separate form group for player search. Improved handling of lineup form initialization and updates to reduce redundant event emissions. Added validation to disable already selected players in the dropdown.
- Integrated a `valueChanges` subscription for `playerIdControl` to keep the player input field and search filter in sync.

<!-- Additional details -->
<details>
<summary><strong>Expand for additional details</strong></summary>

## Screenshots

![image](https://github.com/user-attachments/assets/05fcfb7c-9ce0-4d39-8f55-07f51c40e61c)

</details>
<!-- End of Additional details -->
