### PR TITLE
fix(bb-score): ensure away team loaded for lineup edit

### DIFF
--- a/apps/bb-score/src/app/games/game-card/game-card.component.ts
+++ b/apps/bb-score/src/app/games/game-card/game-card.component.ts
@@ -16,7 +16,6 @@ import { Game } from '../models';
           }})
         </mat-card-title>
         <mat-card-subtitle>
-          <span class="league">{{ game().league }}</span>
           <span class="date">{{ game().date | date: 'fullDate' }}</span>
         </mat-card-subtitle>
       </mat-card-header>

--- a/apps/bb-score/src/app/games/game-create/game-create.component.spec.ts
+++ b/apps/bb-score/src/app/games/game-create/game-create.component.spec.ts
@@ -47,7 +47,6 @@ describe('GameCreateComponent', () => {
 
   it('should create game and dismiss bottom sheet when submitting valid form', async () => {
     component.gameForm.patchValue({
-      league: 'Test League',
       date: new Date(),
       homeTeam: 'Team A',
       awayTeam: 'Team B',

--- a/apps/bb-score/src/app/games/game-create/game-create.component.ts
+++ b/apps/bb-score/src/app/games/game-create/game-create.component.ts
@@ -13,7 +13,6 @@ import { combineLatest, firstValueFrom, Observable, of } from 'rxjs';
 import { map, shareReplay, startWith, switchMap } from 'rxjs/operators';
 import { TeamService } from '../../teams';
 import { GameService } from '../game.service';
-import { Game } from '../models';
 
 @Component({
   selector: 'app-game-create',
@@ -36,112 +35,87 @@ import { Game } from '../models';
         {{ gamesCreated }} game{{ gamesCreated > 1 ? 's' : '' }} created
       </h3>
     </div>
-    <div class="create-form">
-      <form [formGroup]="gameForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>League</mat-label>
-          <input
-            matInput
-            formControlName="league"
-            placeholder="Enter league name"
-            [matAutocomplete]="leagueAuto"
-          />
-          <mat-autocomplete #leagueAuto="matAutocomplete">
-            @for (option of filteredLeagues$ | async; track option) {
-              <mat-option [value]="option">{{ option }}</mat-option>
-            }
-          </mat-autocomplete>
-          @if (inputs.league.hasError('required')) {
-            <mat-error>League is required</mat-error>
-          }
-        </mat-form-field>
+    <form [formGroup]="gameForm" (ngSubmit)="onSubmit()">
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Date</mat-label>
+        <input matInput [matDatepicker]="picker" formControlName="date" />
+        <mat-datepicker-toggle
+          matIconSuffix
+          [for]="picker"
+        ></mat-datepicker-toggle>
+        <mat-datepicker #picker></mat-datepicker>
+        @if (inputs.date.hasError('required')) {
+          <mat-error>Date is required</mat-error>
+        }
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Date</mat-label>
-          <input matInput [matDatepicker]="picker" formControlName="date" />
-          <mat-datepicker-toggle
-            matIconSuffix
-            [for]="picker"
-          ></mat-datepicker-toggle>
-          <mat-datepicker #picker></mat-datepicker>
-          @if (inputs.date.hasError('required')) {
-            <mat-error>Date is required</mat-error>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Home Team</mat-label>
+        <input
+          #homeTeamInput
+          matInput
+          formControlName="homeTeam"
+          placeholder="Enter home team name"
+          [matAutocomplete]="homeTeamAuto"
+        />
+        <mat-autocomplete #homeTeamAuto="matAutocomplete">
+          @for (option of filteredHomeTeams$ | async; track option) {
+            <mat-option [value]="option">{{ option }}</mat-option>
           }
-        </mat-form-field>
+        </mat-autocomplete>
+        @if (inputs.homeTeam.hasError('required')) {
+          <mat-error>Home team is required</mat-error>
+        }
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Home Team</mat-label>
-          <input
-            #homeTeamInput
-            matInput
-            formControlName="homeTeam"
-            placeholder="Enter home team name"
-            [matAutocomplete]="homeTeamAuto"
-          />
-          <mat-autocomplete #homeTeamAuto="matAutocomplete">
-            @for (option of filteredHomeTeams$ | async; track option) {
-              <mat-option [value]="option">{{ option }}</mat-option>
-            }
-          </mat-autocomplete>
-          @if (inputs.homeTeam.hasError('required')) {
-            <mat-error>Home team is required</mat-error>
+      <mat-form-field appearance="outline" class="full-width">
+        <mat-label>Away Team</mat-label>
+        <input
+          matInput
+          formControlName="awayTeam"
+          placeholder="Enter away team name"
+          [matAutocomplete]="awayTeamAuto"
+        />
+        <mat-autocomplete #awayTeamAuto="matAutocomplete">
+          @for (option of filteredAwayTeams$ | async; track option) {
+            <mat-option [value]="option">{{ option }}</mat-option>
           }
-        </mat-form-field>
+        </mat-autocomplete>
+        @if (inputs.awayTeam.hasError('required')) {
+          <mat-error>Away team is required</mat-error>
+        }
+      </mat-form-field>
 
-        <mat-form-field appearance="outline" class="full-width">
-          <mat-label>Away Team</mat-label>
-          <input
-            matInput
-            formControlName="awayTeam"
-            placeholder="Enter away team name"
-            [matAutocomplete]="awayTeamAuto"
-          />
-          <mat-autocomplete #awayTeamAuto="matAutocomplete">
-            @for (option of filteredAwayTeams$ | async; track option) {
-              <mat-option [value]="option">{{ option }}</mat-option>
-            }
-          </mat-autocomplete>
-          @if (inputs.awayTeam.hasError('required')) {
-            <mat-error>Away team is required</mat-error>
-          }
-        </mat-form-field>
-
-        <div class="button-container">
-          <button mat-button type="button" (click)="onCancel()">Cancel</button>
-          <button
-            mat-raised-button
-            color="primary"
-            type="button"
-            [disabled]="!gameForm.valid"
-            (click)="onSubmit(true)"
-          >
-            Add Another Game
-          </button>
-          <button
-            mat-raised-button
-            color="accent"
-            type="submit"
-            [disabled]="!gameForm.valid"
-          >
-            Save and Close
-          </button>
-        </div>
-      </form>
-    </div>
+      <div class="button-container">
+        <button mat-button type="button" (click)="onCancel()">Cancel</button>
+        <button
+          mat-raised-button
+          color="primary"
+          type="button"
+          [disabled]="!gameForm.valid"
+          (click)="onSubmit(true)"
+        >
+          Add Another Game
+        </button>
+        <button
+          mat-raised-button
+          color="accent"
+          type="submit"
+          [disabled]="!gameForm.valid"
+        >
+          Save and Close
+        </button>
+      </div>
+    </form>
   `,
   styles: [
     `
-      .create-form {
-        max-width: 600px;
-      }
-
       .create-header {
         padding: 10px 0;
       }
 
       .full-width {
         width: 100%;
-        margin-bottom: 16px;
       }
 
       .button-container {
@@ -169,7 +143,6 @@ export class GameCreateComponent {
   gamesCreated = 0;
 
   gameForm = this._fb.group({
-    league: ['', Validators.required],
     date: [new Date(), Validators.required],
     homeTeam: ['', Validators.required],
     awayTeam: ['', Validators.required],
@@ -178,9 +151,6 @@ export class GameCreateComponent {
   get inputs() {
     return this.gameForm.controls;
   }
-
-  // Get unique leagues from existing games
-  private _leagues$ = this.getUniqueValues('league');
 
   // Get team names from TeamService
   private _teams$ = this.getTeamNames();
@@ -198,34 +168,18 @@ export class GameCreateComponent {
   );
 
   // Create filtered observables for autocomplete
-  filteredLeagues$ = this.createFilteredObservable('league', this._leagues$);
   filteredHomeTeams$ = this.createFilteredObservable('homeTeam', this._teams$);
   filteredAwayTeams$ = this.createFilteredObservable('awayTeam', this._teams$);
 
-  private getUniqueValues(field: keyof Game): Observable<string[]> {
-    return this._gameService.games$.pipe(
-      map((games) => {
-        const values = new Set<string>();
-        games.forEach((game) => {
-          if (game[field]) {
-            values.add(game[field] as string);
-          }
-        });
-        return Array.from(values);
-      }),
-      shareReplay(1),
-    );
-  }
-
   private getTeamNames(): Observable<string[]> {
-    return this._teamService.getTeams().pipe(
+    return this._teamService.getTeamSummaries().pipe(
       map((teams) => teams.map((team) => team.name)),
       shareReplay(1),
     );
   }
 
   private createFilteredObservable(
-    controlName: 'league' | 'homeTeam' | 'awayTeam',
+    controlName: 'homeTeam' | 'awayTeam',
     options: Observable<string[]>,
   ): Observable<string[]> {
     return (
@@ -264,7 +218,6 @@ export class GameCreateComponent {
       const teams = await firstValueFrom(this._teamIdByName$);
       const fv = this.gameForm.value;
       this._gameService.createGame({
-        league: fv.league as string,
         homeTeamId: teams[fv.homeTeam as string],
         homeTeamName: fv.homeTeam as string,
         awayTeamId: teams[fv.awayTeam as string],
@@ -281,9 +234,7 @@ export class GameCreateComponent {
         nextDate.setDate(nextDate.getDate() + 7);
 
         // Reset form but keep the league and update date
-        const league = this.gameForm.value.league;
         this.gameForm.reset({
-          league,
           date: nextDate,
           homeTeam: '',
           awayTeam: '',

--- a/apps/bb-score/src/app/games/game-list/game-list.component.html
+++ b/apps/bb-score/src/app/games/game-list/game-list.component.html
@@ -9,16 +9,6 @@
 
   <div class="filters">
     <mat-form-field>
-      <mat-label>League</mat-label>
-      <mat-select [formControl]="filters.controls.league">
-        <mat-option [value]="''">All Leagues</mat-option>
-        @for (league of uniqueLeagues(); track league) {
-          <mat-option [value]="league">{{ league }}</mat-option>
-        }
-      </mat-select>
-    </mat-form-field>
-
-    <mat-form-field>
       <mat-label>Team</mat-label>
       <mat-select [formControl]="filters.controls.team">
         <mat-option [value]="''">All Teams</mat-option>

--- a/apps/bb-score/src/app/games/game-list/game-list.component.spec.ts
+++ b/apps/bb-score/src/app/games/game-list/game-list.component.spec.ts
@@ -25,7 +25,6 @@ describe('GameListComponent', () => {
       awayTeamId: 'b',
       awayTeamName: 'Team B',
       awayLineup: undefined,
-      league: 'League A',
     },
     {
       id: '2',
@@ -37,7 +36,6 @@ describe('GameListComponent', () => {
       awayTeamId: 'd',
       awayTeamName: 'Team D',
       awayLineup: undefined,
-      league: 'League B',
     },
   ];
 

--- a/apps/bb-score/src/app/games/game-list/game-list.component.ts
+++ b/apps/bb-score/src/app/games/game-list/game-list.component.ts
@@ -72,16 +72,9 @@ export class GameListComponent {
   games = toSignal(this._gameService.getGames());
 
   filters = this._fb.group({
-    league: [''],
     team: [''],
     status: [''],
   });
-
-  uniqueLeagues = toSignal(
-    this._gameService.games$.pipe(
-      map((games) => [...new Set(games.map((g) => g.league))]),
-    ),
-  );
 
   uniqueTeams = toSignal(
     this._gameService.games$.pipe(
@@ -101,7 +94,6 @@ export class GameListComponent {
       ),
       map(({ games, filters }) => {
         return games.filter((game) => {
-          if (filters.league && game.league !== filters.league) return false;
           if (
             filters.team &&
             game.homeTeamName !== filters.team &&
@@ -118,7 +110,6 @@ export class GameListComponent {
 
   clearFilters(): void {
     this.filters.reset({
-      league: '',
       team: '',
       status: '',
     });

--- a/apps/bb-score/src/app/games/game-score/scoring/scoring.service.spec.ts
+++ b/apps/bb-score/src/app/games/game-score/scoring/scoring.service.spec.ts
@@ -79,7 +79,6 @@ describe('ScoringService', () => {
       homeTeamId: 'h-1',
       homeTeamName: 'Home',
       id: '',
-      league: '',
       snapshots: undefined,
       status: 'pending',
     };

--- a/apps/bb-score/src/app/games/game.service.spec.ts
+++ b/apps/bb-score/src/app/games/game.service.spec.ts
@@ -50,7 +50,6 @@ describe('GameService', () => {
         status: 'pending',
         homeTeamName: 'Team A',
         awayTeamName: 'Team B',
-        league: 'League A',
         homeTeamId: 'a',
         homeLineup: undefined,
         awayTeamId: 'b',
@@ -62,12 +61,10 @@ describe('GameService', () => {
     const games = await firstValueFrom(service.getGames());
     expect(games).toHaveLength(1);
     expect(games[0].id).toBe('1');
-    expect(games[0].league).toBe('League A');
   });
 
   it('should create a new game and save to localStorage', async () => {
     const newGame: Parameters<GameService['createGame']>[0] = {
-      league: 'League 1',
       date: new Date(),
       homeTeamName: 'Team C',
       awayTeamName: 'Team D',
@@ -80,22 +77,19 @@ describe('GameService', () => {
     const games = await firstValueFrom(service.getGames());
     expect(games).toHaveLength(1);
     const createdGame = games[0];
-    expect(createdGame.league).toBe('League 1');
     expect(createdGame.homeTeamName).toBe('Team C');
     expect(createdGame.awayTeamName).toBe('Team D');
     expect(createdGame.status).toBe('pending');
     expect(createdGame.id).toBeDefined();
 
     // Verify localStorage was updated
-    const savedGames = JSON.parse(mockLocalStorage['bb-score-games']);
+    const savedGames = JSON.parse(mockLocalStorage['bb-score-games']) as Game[];
     expect(savedGames).toHaveLength(1);
-    expect(savedGames[0].league).toBe('League 1');
   });
 
   it('should update an existing game and save to localStorage', async () => {
     // First create a game
     const initialGame: Parameters<GameService['createGame']>[0] = {
-      league: 'League 1',
       date: new Date(),
       homeTeamName: 'Team A',
       awayTeamName: 'Team B',
@@ -109,7 +103,6 @@ describe('GameService', () => {
     const gameId = games[0].id;
     const updatedGame: Game = {
       id: gameId,
-      league: 'League 2',
       date: new Date(),
       status: 'in-progress',
       homeTeamName: 'Team A',
@@ -124,19 +117,16 @@ describe('GameService', () => {
 
     const updatedGames = await firstValueFrom(service.getGames());
     const game = updatedGames[0];
-    expect(game.league).toBe('League 2');
     expect(game.status).toBe('in-progress');
 
     // Verify localStorage was updated
-    const savedGames = JSON.parse(mockLocalStorage['bb-score-games']);
-    expect(savedGames[0].league).toBe('League 2');
+    const savedGames = JSON.parse(mockLocalStorage['bb-score-games']) as Game[];
     expect(savedGames[0].status).toBe('in-progress');
   });
 
   it('should delete a game and update localStorage', async () => {
     // First create a game
     const game: Parameters<GameService['createGame']>[0] = {
-      league: 'League 1',
       date: new Date(),
       homeTeamId: 'a',
       homeTeamName: 'Team A',
@@ -160,7 +150,6 @@ describe('GameService', () => {
   it('should get a game by id', async () => {
     // First create a game
     const game: Parameters<GameService['createGame']>[0] = {
-      league: 'League 1',
       date: new Date(),
       homeTeamName: 'Team A',
       awayTeamName: 'Team B',
@@ -206,7 +195,6 @@ describe('GameService', () => {
         homeTeamId: undefined,
         homeTeamName: '',
         id: '',
-        league: '',
         snapshots: undefined,
         status: 'pending',
       };

--- a/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
+++ b/apps/bb-score/src/app/games/lineup-edit/lineup.service.spec.ts
@@ -20,7 +20,6 @@ describe('LineUpService', () => {
       homeTeamId: undefined,
       homeTeamName: '',
       id: '',
-      league: '',
       status: 'pending',
     };
     gameSubject = new BehaviorSubject<Game>(initialGame);

--- a/apps/bb-score/src/app/games/models/game.ts
+++ b/apps/bb-score/src/app/games/models/game.ts
@@ -31,7 +31,6 @@ type Combined = GameWithTeam<'home'> & GameWithTeam<'away'>;
 export interface Game extends Combined {
   id: string;
   date: Date;
-  league: string;
   status: 'pending' | 'in-progress' | 'completed';
   snapshots?: Array<GameSnapshot>;
 }

--- a/apps/bb-score/src/app/teams/models/player.ts
+++ b/apps/bb-score/src/app/teams/models/player.ts
@@ -2,5 +2,4 @@ export interface Player {
   id: string;
   name: string;
   number?: number;
-  league?: string[];
 }

--- a/apps/bb-score/src/app/teams/models/team-summary.ts
+++ b/apps/bb-score/src/app/teams/models/team-summary.ts
@@ -2,6 +2,5 @@ export interface TeamSummary {
   id: string;
   name: string;
   location?: string;
-  leagues?: string[];
   playerCount: number;
 }

--- a/apps/bb-score/src/app/teams/player-edit/player-edit.component.ts
+++ b/apps/bb-score/src/app/teams/player-edit/player-edit.component.ts
@@ -30,9 +30,9 @@ import { TeamService } from '../team.service';
     <div class="edit-header">
       <h1>{{ isEdit ? 'Edit Player' : 'Add Player' }}</h1>
     </div>
-    <div class="edit-form">
-      <form [formGroup]="playerForm" (ngSubmit)="onSubmit()">
-        <mat-form-field appearance="outline" class="full-width">
+    <form [formGroup]="playerForm" (ngSubmit)="onSubmit()">
+      <div class="form-row">
+        <mat-form-field appearance="outline" class="grow">
           <mat-label>Player Name</mat-label>
           <input
             matInput
@@ -44,63 +44,48 @@ import { TeamService } from '../team.service';
           }
         </mat-form-field>
 
-        <div class="form-row">
-          <mat-form-field appearance="outline" class="half-width">
-            <mat-label>Number</mat-label>
-            <input
-              matInput
-              formControlName="number"
-              type="number"
-              placeholder="Jersey number"
-            />
-          </mat-form-field>
+        <mat-form-field appearance="outline">
+          <mat-label>Number</mat-label>
+          <input
+            matInput
+            formControlName="number"
+            type="number"
+            placeholder="Jersey number"
+          />
+        </mat-form-field>
+      </div>
 
-          <mat-form-field appearance="outline" class="half-width">
-            <mat-label>Registered league(s)</mat-label>
-            <input
-              matInput
-              formControlName="league"
-              placeholder="League(s) separated by spaces"
-            />
-          </mat-form-field>
-        </div>
-
-        <div class="button-container">
-          <button mat-button type="button" (click)="onCancel()">Cancel</button>
-          <button
-            mat-raised-button
-            color="primary"
-            type="submit"
-            [disabled]="!playerForm.valid"
-          >
-            {{ isEdit ? 'Update Player' : 'Add Player' }}
-          </button>
-        </div>
-      </form>
-    </div>
+      <div class="button-container">
+        <button mat-button type="button" (click)="onCancel()">Cancel</button>
+        <button
+          mat-raised-button
+          color="primary"
+          type="submit"
+          [disabled]="!playerForm.valid"
+        >
+          {{ isEdit ? 'Update Player' : 'Add Player' }}
+        </button>
+      </div>
+    </form>
   `,
   styles: [
     `
-      .edit-form {
-        max-width: 600px;
-      }
-
       .edit-header {
         padding: 10px 0;
       }
 
-      .full-width {
-        width: 100%;
-        margin-bottom: 16px;
-      }
-
       .form-row {
         display: flex;
+        flex-direction: column;
         gap: 16px;
+
+        @media (min-width: 500px) {
+          flex-direction: row;
+        }
       }
 
-      .half-width {
-        width: 50%;
+      .grow {
+        flex-grow: 1;
       }
 
       .button-container {
@@ -141,7 +126,6 @@ export class PlayerEditComponent {
   playerForm = this._fb.group({
     name: [this._data.player?.name ?? '', Validators.required],
     number: [this._data.player?.number ?? (null as number | null)],
-    league: [this._data.player?.league?.join(' ') ?? ''],
   });
 
   onCancel(): void {
@@ -159,7 +143,6 @@ export class PlayerEditComponent {
     const playerData: Omit<Player, 'id'> = {
       name: this.playerForm.value.name as string,
       number: this.playerForm.value.number || undefined,
-      league: (this.playerForm.value.league ?? '').split(' ').filter((l) => l),
     };
 
     let resultPlayer$: Observable<Player | null>;

--- a/apps/bb-score/src/app/teams/team-detail/team-detail.component.ts
+++ b/apps/bb-score/src/app/teams/team-detail/team-detail.component.ts
@@ -1,5 +1,5 @@
 import { CommonModule } from '@angular/common';
-import { Component, computed, inject } from '@angular/core';
+import { Component, inject } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import {
   MatBottomSheet,
@@ -42,9 +42,6 @@ import { TeamService } from '../team.service';
       <mat-card>
         <mat-card-content>
           <div class="team-info">
-            <p *ngIf="uniqueLeagues()">
-              <strong>League(s):</strong> {{ uniqueLeagues() }}
-            </p>
             <p><strong>Players:</strong> {{ team.players.length }}</p>
           </div>
         </mat-card-content>
@@ -92,11 +89,6 @@ import { TeamService } from '../team.service';
                   <span matListItemLine *ngIf="player.number">
                     # {{ player.number }}
                   </span>
-                  @if (player.league; as playerLeagues) {
-                    <span matListItemLine>
-                      {{ playerLeagues.join(', ') }}
-                    </span>
-                  }
                 </mat-list-item>
               }
             </mat-nav-list>
@@ -165,14 +157,6 @@ export class TeamDetailComponent {
   private _bottomSheet = inject(MatBottomSheet);
 
   team = toSignal(this._teamService.selectedTeam$);
-  uniqueLeagues = computed(() => {
-    const team = this.team();
-    if (!team) return '';
-    const unique = team.players
-      .flatMap((player) => player.league ?? [])
-      .filter((v, i, a) => a.indexOf(v) === i);
-    return unique.join(', ');
-  });
 
   goBack(): void {
     this._router.navigate(['/teams']);

--- a/apps/bb-score/src/app/teams/team.service.spec.ts
+++ b/apps/bb-score/src/app/teams/team.service.spec.ts
@@ -38,14 +38,13 @@ describe('TeamService', () => {
   });
 
   it('should initialize with empty array when no saved teams exist', async () => {
-    const teams = await firstValueFrom(service.getTeams());
+    const teams = await firstValueFrom(service.getTeamSummaries());
     expect(teams).toHaveLength(0);
   });
 
   it('should load saved teams from localStorage', async () => {
     const player: Player = {
       id: '2',
-      league: ['League', 'League2'],
       name: 'Player1',
       number: 123,
     };
@@ -61,18 +60,16 @@ describe('TeamService', () => {
             id: '3',
             name: 'Player2',
             number: 456,
-            league: ['League'],
           },
         ],
       },
     ];
     mockLocalStorage['bb-score-teams'] = JSON.stringify(savedTeams);
 
-    const teams = await firstValueFrom(service.getTeams());
+    const teams = await firstValueFrom(service.getTeamSummaries());
     expect(teams).toHaveLength(1);
     expect(teams[0].id).toBe('1');
     expect(teams[0].name).toBe('Team A');
-    expect(teams[0].leagues).toEqual(['League', 'League2']);
     expect(teams[0].location).toBe('Loc1');
     expect(teams[0].playerCount).toBe(2);
   });
@@ -85,7 +82,7 @@ describe('TeamService', () => {
 
     service.createTeam(newTeam);
 
-    const teams = await firstValueFrom(service.getTeams());
+    const teams = await firstValueFrom(service.getTeamSummaries());
     expect(teams).toHaveLength(1);
     const createdTeam = teams[0];
     expect(createdTeam.name).toBe('Team B');
@@ -122,7 +119,7 @@ describe('TeamService', () => {
 
       service.updateTeam(updatedTeam);
 
-      const updatedTeams = await firstValueFrom(service.getTeams());
+      const updatedTeams = await firstValueFrom(service.getTeamSummaries());
       const team = updatedTeams[0];
       expect(team.name).toBe('Team A Updated');
       expect(team.location).toBe('Loc2');
@@ -139,7 +136,7 @@ describe('TeamService', () => {
       const teamId = createdTeam.id;
       service.deleteTeam(teamId);
 
-      const remainingTeams = await firstValueFrom(service.getTeams());
+      const remainingTeams = await firstValueFrom(service.getTeamSummaries());
       expect(remainingTeams).toHaveLength(0);
 
       // Verify localStorage was updated
@@ -171,7 +168,6 @@ describe('TeamService', () => {
     const player: Omit<Player, 'id'> = {
       name: 'John Doe',
       number: 23,
-      league: ['League 1'],
     };
     service.addPlayer(team.id, player);
 
@@ -180,7 +176,6 @@ describe('TeamService', () => {
     expect(updatedTeam?.players).toHaveLength(1);
     expect(updatedTeam?.players[0].name).toBe('John Doe');
     expect(updatedTeam?.players[0].number).toBe(23);
-    expect(updatedTeam?.players[0].league).toEqual(['League 1']);
   });
 
   describe('player management', () => {
@@ -195,7 +190,6 @@ describe('TeamService', () => {
         players: [
           {
             id: 'p-1',
-            league: [],
             number: 23,
             name: 'John Doe',
           },
@@ -212,7 +206,6 @@ describe('TeamService', () => {
         id: playerId,
         name: 'John Doe Jr.',
         number: 24,
-        league: ['League 1'],
       };
       service.updatePlayer(teamId, updatedPlayer);
 
@@ -221,7 +214,6 @@ describe('TeamService', () => {
       expect(updatedTeam?.players).toHaveLength(1);
       expect(updatedTeam?.players[0].name).toBe('John Doe Jr.');
       expect(updatedTeam?.players[0].number).toBe(24);
-      expect(updatedTeam?.players[0].league).toEqual(['League 1']);
     });
 
     it('should remove a player from a team', async () => {

--- a/apps/bb-score/src/app/teams/teams-list/teams-list.component.ts
+++ b/apps/bb-score/src/app/teams/teams-list/teams-list.component.ts
@@ -47,11 +47,6 @@ import { TeamService } from '../team.service';
                 @for (team of teams; track team.id) {
                   <a mat-list-item (click)="viewTeam(team.id)">
                     <span matListItemTitle>{{ team.name }}</span>
-                    @if (team.leagues; as leagues) {
-                      <div matListItemLine>
-                        {{ leagues.join(', ') }}
-                      </div>
-                    }
                     <span matListItemLine>
                       {{ team.playerCount }} player(s)
                     </span>
@@ -107,7 +102,7 @@ export class TeamsListComponent {
   private _bottomSheet = inject(MatBottomSheet);
   private _router = inject(Router);
 
-  teams$ = this._teamService.getTeams();
+  teams$ = this._teamService.getTeamSummaries();
 
   openCreateTeam(): void {
     this._bottomSheet.open(TeamCreateComponent);


### PR DESCRIPTION
<!-- markdownlint-disable first-line-heading -->

## Checklist

- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

## Details

- Updated game selection logic in GameService to be driven by selected ID
- Replaced `getTeams` with `getTeamSummaries` for better abstraction of team summaries. Refactored selected team logic to use `teamId` and streamlined team addition, updates, and deletions. Updated dependent components and tests to align with these changes.
- Removed `league` from team, player, and game
